### PR TITLE
Refine putters fetch effect debounce

### DIFF
--- a/app/putters/page.js
+++ b/app/putters/page.js
@@ -412,6 +412,7 @@ useEffect(() => {
     setFetchedCount(null); setKeptCount(null);
     setApiData(null);
     setErr("");
+    setLoading(false);
     return;
   }
 
@@ -538,23 +539,12 @@ useEffect(() => {
     }
   } // end run()
 
-  useEffect(() => {
-  let ignore = false;
-  const ctrl = new AbortController();
+  const t = setTimeout(() => { run(); }, 150);
 
-  const run = async () => {
-    // ... your fetch logic ...
-  };
-
-  const t = setTimeout(run, 150);
-
-  // âŒ REMOVE these from inside the effect:
-  // const baseStatsByModel = useMemo(() => { ... }, [groupMode, groups, offers]);
-
-  return () => { 
-    ignore = true; 
-    clearTimeout(t); 
-    ctrl.abort(); 
+  return () => {
+    ignore = true;
+    ctrl.abort();
+    clearTimeout(t);
   };
 }, [apiUrl, groupMode, sortBy, q, page]); // <-- END of Fetch results effect
 


### PR DESCRIPTION
## Summary
- clean up the fetch effect for the putters page to remove the nested placeholder hook
- ensure the effect handles empty queries and debounce timing with a single cleanup path

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d72bd7568c8325a2d417ec59c6ee3c