### PR TITLE
Fix fetch effect invocation and cleanup

### DIFF
--- a/app/putters/page.js
+++ b/app/putters/page.js
@@ -538,25 +538,17 @@ useEffect(() => {
     }
   } // end run()
 
-  useEffect(() => {
-  let ignore = false;
-  const ctrl = new AbortController();
+  const timeoutId = setTimeout(() => {
+    run();
+  }, 150);
 
-  const run = async () => {
-    // ... your fetch logic ...
-  };
-
-  const t = setTimeout(run, 150);
-
-  // âŒ REMOVE these from inside the effect:
-  // const baseStatsByModel = useMemo(() => { ... }, [groupMode, groups, offers]);
-
-  return () => { 
-    ignore = true; 
-    clearTimeout(t); 
-    ctrl.abort(); 
+  return () => {
+    ignore = true;
+    clearTimeout(timeoutId);
+    ctrl.abort();
   };
 }, [apiUrl, groupMode, sortBy, q, page]); // <-- END of Fetch results effect
+
 
 // Safely derive the listings used for stats (no early returns needed)
 const listingsForStats = useMemo(() => {


### PR DESCRIPTION
## Summary
- remove the placeholder nested useEffect from the fetch results hook
- invoke the existing run() helper via a timeout and clean up the timer and abort controller

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7350288888325867a9ebe28c44294