### PR TITLE
Improve tokenizer for alphanumeric titles

### DIFF
--- a/pages/api/putters.js
+++ b/pages/api/putters.js
@@ -111,7 +111,10 @@ const norm = (s) => String(s || "").trim().toLowerCase();
 
 const tokenize = (s) => {
   if (!s) return [];
-  return norm(s)
+  const normalized = norm(s)
+    .replace(/([a-z])([0-9])/gi, "$1 $2")
+    .replace(/([0-9])([a-z])/gi, "$1 $2");
+  return normalized
     .replace(/[^a-z0-9]+/gi, " ")
     .split(" ")
     .map((t) => t.trim())


### PR DESCRIPTION
## Summary
- insert separators between letter and digit transitions so the tokenizer preserves numeric model tokens
- rely on the normalized tokens in the existing query/title filter to keep comparisons consistent

## Testing
- npm run dev
- curl -s 'http://localhost:3000/api/putters?q=phantom%20x%207' | head


------
https://chatgpt.com/codex/tasks/task_e_68d776c719688325bfb0cdd091cdde55