### PR TITLE
Fix alphanumeric tokenization for putter search

### DIFF
--- a/pages/api/putters.js
+++ b/pages/api/putters.js
@@ -111,14 +111,28 @@ const norm = (s) => String(s || "").trim().toLowerCase();
 
 const tokenize = (s) => {
   if (!s) return [];
-  const normalized = norm(s)
+
+  const normalized = norm(s);
+  const tokenSet = new Set();
+
+  const spaced = normalized
     .replace(/([a-z])([0-9])/gi, "$1 $2")
     .replace(/([0-9])([a-z])/gi, "$1 $2");
-  return normalized
+
+  spaced
     .replace(/[^a-z0-9]+/gi, " ")
     .split(" ")
     .map((t) => t.trim())
-    .filter(Boolean);
+    .filter(Boolean)
+    .forEach((t) => tokenSet.add(t));
+
+  const alphaNumPattern = /[a-z]+[0-9]+|[0-9]+[a-z]+/g;
+  let match;
+  while ((match = alphaNumPattern.exec(normalized))) {
+    tokenSet.add(match[0]);
+  }
+
+  return Array.from(tokenSet);
 };
 
 function pickCheapestShipping(shippingOptions) {


### PR DESCRIPTION
## Summary
- update the API tokenization helper to retain contiguous alphanumeric strings alongside separated tokens
- deduplicate and lowercase tokens so downstream comparisons continue to behave as expected

## Testing
- npm run build
- node - <<'NODE' ... (manual token comparison script)


------
https://chatgpt.com/codex/tasks/task_e_68d778d37b4483259443ca2adbaf0a5e