### PR TITLE
Handle whitespace-separated alphanumeric tokens

### DIFF
--- a/pages/api/putters.js
+++ b/pages/api/putters.js
@@ -132,8 +132,20 @@ const tokenize = (s) => {
     tokenSet.add(match[0]);
   }
 
+  const letterDigitWithGap = /([a-z])\s+([0-9]+)/g;
+  while ((match = letterDigitWithGap.exec(normalized))) {
+    tokenSet.add(`${match[1]}${match[2]}`);
+  }
+
+  const digitLetterWithGap = /([0-9]+)\s+([a-z])/g;
+  while ((match = digitLetterWithGap.exec(normalized))) {
+    tokenSet.add(`${match[1]}${match[2]}`);
+  }
+
   return Array.from(tokenSet);
 };
+
+export { tokenize };
 
 function pickCheapestShipping(shippingOptions) {
   if (!Array.isArray(shippingOptions) || shippingOptions.length === 0) return null;

--- a/scripts/check-tokenize.mjs
+++ b/scripts/check-tokenize.mjs
@@ -1,0 +1,41 @@
+import { tokenize } from "../pages/api/putters.js";
+
+const cases = [
+  {
+    input: "Phantom X 7",
+    expectContains: ["x7"],
+    expectNotContains: [],
+  },
+  {
+    input: "Odyssey #7",
+    expectContains: [],
+    expectNotContains: ["x7"],
+  },
+];
+
+let failures = 0;
+
+for (const test of cases) {
+  const tokens = tokenize(test.input);
+  for (const mustHave of test.expectContains) {
+    if (!tokens.includes(mustHave)) {
+      console.error(`Expected tokenize("${test.input}") to include "${mustHave}". Tokens:`, tokens);
+      failures += 1;
+    }
+  }
+  for (const mustNotHave of test.expectNotContains) {
+    if (tokens.includes(mustNotHave)) {
+      console.error(
+        `Expected tokenize("${test.input}") to omit "${mustNotHave}". Tokens:`,
+        tokens,
+      );
+      failures += 1;
+    }
+  }
+}
+
+if (failures > 0) {
+  process.exitCode = 1;
+} else {
+  console.log("All tokenize regression checks passed.");
+}


### PR DESCRIPTION
## Summary
- add whitespace bridge handling in the tokenize helper so letter-digit pairs become combined tokens
- expose tokenize for reuse and add a regression script that checks Phantom X 7 and Odyssey #7 cases

## Testing
- `node scripts/check-tokenize.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68d77b6f41e483258f779ec38fd250aa