### PR TITLE
Normalize offer shipping totals

### DIFF
--- a/components/CompareModal.jsx
+++ b/components/CompareModal.jsx
@@ -15,8 +15,37 @@ export default function CompareModal({ open, onClose, items }) {
     ['Title', (o)=> o.title],
     ['Retailer', (o)=> o.retailer],
     ['Price', (o)=> fmt(o.price, o.currency)],
-    ['Shipping', (o)=> ('shipping' in o ? fmt(o.shipping, o.currency) : '—')],
-    ['Total', (o)=> ('total' in o ? fmt(o.total, o.currency) : fmt(o.price, o.currency))],
+    ['Shipping', (o)=> {
+      const cur = o?.shippingDetails?.currency || o.currency;
+      const shipVal = typeof o.shipping === 'number' && Number.isFinite(o.shipping) ? o.shipping : null;
+      let detailVal = null;
+      if (o?.shippingDetails?.cost != null) {
+        const maybe = Number(o.shippingDetails.cost);
+        if (Number.isFinite(maybe)) detailVal = maybe;
+      }
+      const val = shipVal ?? detailVal;
+      return val != null ? fmt(val, cur) : '—';
+    }],
+    ['Total', (o)=> {
+      const totalVal = typeof o.total === 'number' && Number.isFinite(o.total) ? o.total : null;
+      let priceVal = null;
+      if (typeof o.price === 'number' && Number.isFinite(o.price)) {
+        priceVal = o.price;
+      } else if (o.price != null) {
+        const maybe = Number(o.price);
+        if (Number.isFinite(maybe)) priceVal = maybe;
+      }
+      const shipVal = (() => {
+        if (typeof o.shipping === 'number' && Number.isFinite(o.shipping)) return o.shipping;
+        if (o?.shippingDetails?.cost != null) {
+          const maybe = Number(o.shippingDetails.cost);
+          if (Number.isFinite(maybe)) return maybe;
+        }
+        return 0;
+      })();
+      const val = totalVal != null ? totalVal : priceVal != null ? priceVal + shipVal : null;
+      return val != null ? fmt(val, o.currency) : '—';
+    }],
     ['Seller', (o)=> o?.seller?.username ? `@${o.seller.username}` : '—'],
     ['Feedback %', (o)=> (typeof o?.seller?.feedbackPct === 'number' ? `${o.seller.feedbackPct.toFixed(1)}%` : '—')],
     ['Dexterity', (o)=> (o?.specs?.dexterity || '').toUpperCase() || '—'],

--- a/components/CompareTray.jsx
+++ b/components/CompareTray.jsx
@@ -21,6 +21,8 @@ export default function CompareTray({
     { key: 'image',    label: '' },
     { key: 'title',    label: 'Listing' },
     { key: 'price',    label: 'Price' },
+    { key: 'shipping', label: 'Shipping' },
+    { key: 'total',    label: 'Total' },
     { key: 'dex',      label: 'Dexterity' },
     { key: 'head',     label: 'Head' },
     { key: 'length',   label: 'Length' },
@@ -92,6 +94,41 @@ export default function CompareTray({
                       <div className="text-xs text-gray-500">{o.retailer}{o?.seller?.username ? ` · @${o.seller.username}` : ''}</div>
                     </td>
                     <td className="px-3 py-2 font-semibold">{fmt(o.price, o.currency)}</td>
+                    <td className="px-3 py-2">{
+                      (() => {
+                        const cur = o?.shippingDetails?.currency || o.currency;
+                        const flat = typeof o.shipping === 'number' && Number.isFinite(o.shipping) ? o.shipping : null;
+                        let detail = null;
+                        if (o?.shippingDetails?.cost != null) {
+                          const maybe = Number(o.shippingDetails.cost);
+                          if (Number.isFinite(maybe)) detail = maybe;
+                        }
+                        const val = flat ?? detail;
+                        return val != null ? fmt(val, cur) : '—';
+                      })()
+                    }</td>
+                    <td className="px-3 py-2 font-semibold">{
+                      (() => {
+                        const totalVal = typeof o.total === 'number' && Number.isFinite(o.total) ? o.total : null;
+                        let priceVal = null;
+                        if (typeof o.price === 'number' && Number.isFinite(o.price)) {
+                          priceVal = o.price;
+                        } else if (o.price != null) {
+                          const maybe = Number(o.price);
+                          if (Number.isFinite(maybe)) priceVal = maybe;
+                        }
+                        const shipVal = (() => {
+                          if (typeof o.shipping === 'number' && Number.isFinite(o.shipping)) return o.shipping;
+                          if (o?.shippingDetails?.cost != null) {
+                            const maybe = Number(o.shippingDetails.cost);
+                            if (Number.isFinite(maybe)) return maybe;
+                          }
+                          return 0;
+                        })();
+                        const val = totalVal != null ? totalVal : priceVal != null ? priceVal + shipVal : null;
+                        return val != null ? fmt(val, o.currency) : '—';
+                      })()
+                    }</td>
                     <td className="px-3 py-2">{dex}</td>
                     <td className="px-3 py-2">{head}</td>
                     <td className="px-3 py-2">{L}</td>

--- a/pages/api/putters.js
+++ b/pages/api/putters.js
@@ -575,8 +575,8 @@ export default async function handler(req, res) {
       const family = specs?.family || null;
 
       const itemPrice = safeNum(item?.price?.value);
-      const shipCost = shipping?.cost ?? 0;
-      const totalPrice = itemPrice != null && shipCost != null ? itemPrice + shipCost : itemPrice ?? null;
+      const shippingValue = Number.isFinite(shipping?.cost) ? shipping.cost : null;
+      const total = itemPrice != null ? itemPrice + (shippingValue ?? 0) : itemPrice ?? null;
 
       const rawUrl = item?.itemWebUrl || item?.itemHref;
       const url = decorateEbayUrl(rawUrl);
@@ -589,13 +589,13 @@ export default async function handler(req, res) {
         title: item?.title,
         retailer: "eBay",
         price: itemPrice,
+        shipping: shippingValue,
+        total,
         currency: item?.price?.currency || "USD",
         condition: item?.condition || null,
         createdAt: item?.itemCreationDate || item?.itemEndDate || item?.estimatedAvailDate || null,
         image,
-
-        totalPrice,
-        shipping: shipping
+        shippingDetails: shipping
           ? {
               cost: shipping.cost,
               currency: shipping.currency || item?.price?.currency || "USD",

--- a/pages/api/sources/2ndswing.js
+++ b/pages/api/sources/2ndswing.js
@@ -251,25 +251,31 @@ module.exports = async function handler(req, res) {
     log.counts.final = dedup.length;
 
     // ---- 5) Map to Offer shape ----
-    const out = dedup.map((p) => ({
-      source: "2ndswing",
-      retailer: "2nd Swing",
-      productId: p.url,
-      url: p.url,
-      title: p.title,
-      image: p.image,
-      price: p.price,
-      currency: "USD",
-      condition: "USED",
-      specs: {},
-      createdAt: new Date().toISOString(),
-      __model: p.title
-        .toLowerCase()
-        .replace(/\s+/g, " ")
-        .replace(/putter|golf/g, "")
-        .trim()
-        .slice(0, 80),
-    }));
+    const out = dedup.map((p) => {
+      const price = Number.isFinite(p.price) ? Number(p.price) : null;
+      return {
+        source: "2ndswing",
+        retailer: "2nd Swing",
+        productId: p.url,
+        url: p.url,
+        title: p.title,
+        image: p.image,
+        price,
+        shipping: null,
+        total: price,
+        shippingDetails: null,
+        currency: "USD",
+        condition: "USED",
+        specs: {},
+        createdAt: new Date().toISOString(),
+        __model: p.title
+          .toLowerCase()
+          .replace(/\s+/g, " ")
+          .replace(/putter|golf/g, "")
+          .trim()
+          .slice(0, 80),
+      };
+    });
 
     return trace ? res.status(200).json({ out, trace: log }) : res.status(200).json(out);
   } catch (e) {


### PR DESCRIPTION
## Summary
- flatten eBay offer payloads to expose numeric `shipping` and `total` fields while preserving metadata under `shippingDetails`
- align the 2nd Swing source output with the same shape for merged offers
- update compare UI surfaces to read the flattened fields with fallbacks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d80a6e073c8325a5bd85b69795b6d0