### PR TITLE
Add shared putter catalog for cron query generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,37 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+## Overview
 
-## Getting Started
+This project tracks secondary-market pricing for popular putter models by polling the eBay Browse API on a schedule and surfacing the results in a Next.js dashboard.
 
-First, run the development server:
+## Shared putter catalog
+
+Seed searches, UI filters, and future normalization work pull from a single list of brand/model pairs in `lib/data/putterCatalog.js`. Each entry in `PUTTER_CATALOG` is a `{ brand, model }` object, kept alphabetical by brand to minimize merge conflicts.
+
+To add or edit models:
+
+1. Update `lib/data/putterCatalog.js` with the new `{ brand, model }` rows.
+2. Keep brands grouped alphabetically and prefer the naming conventions used by the OEM so the queries match how listings are titled.
+3. If the models also appear in other systems (CMS, Google Sheet, etc.), this file can import that configuration instead. Export the array from your integration so `PUTTER_CATALOG` remains the single source of truth and the API route continues to work without code changes.
+
+The file also exports `PUTTER_SEED_QUERIES`, which is automatically derived from the catalog and used by the cron job.
+
+You can count the entries at any time with:
+
+```bash
+node -e "import('./lib/data/putterCatalog.js').then(m => console.log(m.PUTTER_CATALOG.length))"
+```
+
+## Cron query generation and eBay API limits
+
+`pages/api/cron/collect-prices.js` builds its `SEED_QUERIES` array directly from `PUTTER_SEED_QUERIES`, so every brand/model pair in the catalog results in a search query shaped like `${brand} ${model} putter`.
+
+The cron currently fetches two pages (100 items max) per query, so each catalog entry results in at most two Browse API requests. With the current catalog of 110 putters, that is 220 calls per execution, comfortably below eBay's default 5,000-call daily cap for the Browse API. When adding a large number of models, re-run the count command above and ensure `catalogSize * 2` stays below your account's allocation (visible in the [eBay developer portal](https://developer.ebay.com/api-docs/buy/static/overview.html)).
+
+## Local development
+
+Run the development server with:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+The app will be available at [http://localhost:3000](http://localhost:3000). The page auto-updates as you edit source files.

--- a/lib/data/putterCatalog.js
+++ b/lib/data/putterCatalog.js
@@ -1,0 +1,167 @@
+// lib/data/putterCatalog.js
+// Shared catalog of brand/model pairs that drive search, normalization, and UI options.
+// Keep the list alphabetical by brand so merge conflicts stay small.
+
+export const PUTTER_CATALOG = [
+  // Bettinardi
+  { brand: 'Bettinardi', model: 'Queen B' },
+  { brand: 'Bettinardi', model: 'Studio Stock' },
+  { brand: 'Bettinardi', model: 'BB Series' },
+  { brand: 'Bettinardi', model: 'Inovai' },
+  { brand: 'Bettinardi', model: 'Hive' },
+  { brand: 'Bettinardi', model: 'DASS' },
+
+  // Cleveland
+  { brand: 'Cleveland', model: 'Frontline' },
+  { brand: 'Cleveland', model: 'Huntington Beach' },
+  { brand: 'Cleveland', model: 'HB Soft Milled' },
+
+  // Cobra
+  { brand: 'Cobra', model: 'King 3D' },
+  { brand: 'Cobra', model: 'Vintage Nova' },
+  { brand: 'Cobra', model: 'Vintage Sport' },
+
+  // Edel
+  { brand: 'Edel', model: 'SMS' },
+  { brand: 'Edel', model: 'EAS' },
+
+  // Evnroll
+  { brand: 'Evnroll', model: 'ER1' },
+  { brand: 'Evnroll', model: 'ER2' },
+  { brand: 'Evnroll', model: 'ER5' },
+  { brand: 'Evnroll', model: 'ER8' },
+  { brand: 'Evnroll', model: 'ER10' },
+
+  // Kirkland
+  { brand: 'Kirkland', model: 'KS1' },
+
+  // LAB Golf
+  { brand: 'LAB Golf', model: 'Mezz' },
+  { brand: 'LAB Golf', model: 'Mezz 1 Max' },
+  { brand: 'LAB Golf', model: 'DF 2.1' },
+  { brand: 'LAB Golf', model: 'Link 1' },
+  { brand: 'LAB Golf', model: 'Directed Force' },
+
+  // Miura
+  { brand: 'Miura', model: 'KM-008' },
+
+  // Mizuno
+  { brand: 'Mizuno', model: 'M Craft' },
+  { brand: 'Mizuno', model: 'M Craft OMOI' },
+
+  // Odyssey
+  { brand: 'Odyssey', model: 'Two Ball' },
+  { brand: 'Odyssey', model: 'Eleven' },
+  { brand: 'Odyssey', model: 'Seven' },
+  { brand: 'Odyssey', model: 'Ten' },
+  { brand: 'Odyssey', model: 'Versa' },
+  { brand: 'Odyssey', model: 'Jailbird' },
+  { brand: 'Odyssey', model: 'White Hot OG' },
+  { brand: 'Odyssey', model: 'Tri Hot 5K' },
+  { brand: 'Odyssey', model: 'Stroke Lab' },
+
+  // Ping
+  { brand: 'Ping', model: 'Anser' },
+  { brand: 'Ping', model: 'DS72' },
+  { brand: 'Ping', model: 'Tyne' },
+  { brand: 'Ping', model: 'PLD' },
+  { brand: 'Ping', model: 'Prime Tyne' },
+  { brand: 'Ping', model: 'Fetch' },
+  { brand: 'Ping', model: 'Oslo' },
+  { brand: 'Ping', model: 'B60' },
+
+  // Piretti
+  { brand: 'Piretti', model: 'Potenza' },
+  { brand: 'Piretti', model: 'Matera' },
+
+  // PXG
+  { brand: 'PXG', model: 'Battle Ready' },
+  { brand: 'PXG', model: 'Closer' },
+  { brand: 'PXG', model: 'Blackjack' },
+  { brand: 'PXG', model: 'Spitfire' },
+
+  // Rife
+  { brand: 'Rife', model: 'Switchback' },
+  { brand: 'Rife', model: 'Titan' },
+  { brand: 'Rife', model: 'Two Bar' },
+
+  // Scotty Cameron
+  { brand: 'Scotty Cameron', model: 'Newport 2' },
+  { brand: 'Scotty Cameron', model: 'Newport' },
+  { brand: 'Scotty Cameron', model: 'Phantom X 5' },
+  { brand: 'Scotty Cameron', model: 'Phantom X 7' },
+  { brand: 'Scotty Cameron', model: 'Phantom X 9' },
+  { brand: 'Scotty Cameron', model: 'Phantom X 11' },
+  { brand: 'Scotty Cameron', model: 'Squareback' },
+  { brand: 'Scotty Cameron', model: 'Fastback' },
+  { brand: 'Scotty Cameron', model: 'Futura' },
+  { brand: 'Scotty Cameron', model: 'Button Back' },
+  { brand: 'Scotty Cameron', model: 'TeI3' },
+  { brand: 'Scotty Cameron', model: 'Studio Select' },
+  { brand: 'Scotty Cameron', model: 'Studio Style' },
+  { brand: 'Scotty Cameron', model: 'Special Select' },
+  { brand: 'Scotty Cameron', model: 'Champions Choice' },
+  { brand: 'Scotty Cameron', model: 'Jet Set' },
+  { brand: 'Scotty Cameron', model: 'Newport Beach' },
+  { brand: 'Scotty Cameron', model: 'Napa' },
+  { brand: 'Scotty Cameron', model: 'Circle T' },
+  { brand: 'Scotty Cameron', model: 'Catalina' },
+  { brand: 'Scotty Cameron', model: 'GoLo' },
+  { brand: 'Scotty Cameron', model: 'Detour' },
+  { brand: 'Scotty Cameron', model: 'Laguna' },
+  { brand: 'Scotty Cameron', model: 'Monterey' },
+
+  // SeeMore
+  { brand: 'SeeMore', model: 'FGP' },
+  { brand: 'SeeMore', model: 'Mini Giant' },
+  { brand: 'SeeMore', model: 'Nashville Studio' },
+
+  // SIK
+  { brand: 'SIK', model: 'Flo' },
+  { brand: 'SIK', model: 'Pro' },
+  { brand: 'SIK', model: 'Sho' },
+
+  // Swag Golf
+  { brand: 'Swag Golf', model: 'Savage Too' },
+  { brand: 'Swag Golf', model: 'Handsome One' },
+
+  // TaylorMade
+  { brand: 'TaylorMade', model: 'Spider Tour' },
+  { brand: 'TaylorMade', model: 'Spider X' },
+  { brand: 'TaylorMade', model: 'Spider GT' },
+  { brand: 'TaylorMade', model: 'Spider GTX' },
+  { brand: 'TaylorMade', model: 'Spider S' },
+  { brand: 'TaylorMade', model: 'Spider Tour Z' },
+  { brand: 'TaylorMade', model: 'TP Reserve' },
+  { brand: 'TaylorMade', model: 'TP Patina' },
+  { brand: 'TaylorMade', model: 'TP Collection' },
+  { brand: 'TaylorMade', model: 'Truss' },
+  { brand: 'TaylorMade', model: 'Ghost Spider' },
+
+  // Toulon
+  { brand: 'Toulon', model: 'Atlanta' },
+  { brand: 'Toulon', model: 'Memphis' },
+  { brand: 'Toulon', model: 'San Diego' },
+  { brand: 'Toulon', model: 'Las Vegas' },
+  { brand: 'Toulon', model: 'Garage' },
+  { brand: 'Toulon', model: 'Madison' },
+  { brand: 'Toulon', model: 'Chicago' },
+  { brand: 'Toulon', model: 'Daytona' },
+
+  // Wilson
+  { brand: 'Wilson', model: '8802' },
+  { brand: 'Wilson', model: 'Staff Model' },
+
+  // Yes!
+  { brand: 'Yes!', model: 'C-Groove' },
+  { brand: 'Yes!', model: 'Tracy' },
+  { brand: 'Yes!', model: 'Natalie' },
+];
+
+export const PUTTER_SEED_QUERIES = PUTTER_CATALOG.map(({ brand, model }) =>
+  `${brand} ${model} putter`.toLowerCase()
+);
+
+export function catalogSize() {
+  return PUTTER_CATALOG.length;
+}

--- a/pages/api/cron/collect-prices.js
+++ b/pages/api/cron/collect-prices.js
@@ -4,6 +4,7 @@ export const runtime = 'nodejs';
 import { getSql } from '../../../lib/db';
 import { getEbayToken } from '../../../lib/ebayAuth';
 import { normalizeModelKey } from '../../../lib/normalize';
+import { PUTTER_SEED_QUERIES } from '../../../lib/data/putterCatalog';
 
 // --- simple auth: header or query param must match CRON_SECRET ---
 function isAuthorized(req) {
@@ -13,71 +14,8 @@ function isAuthorized(req) {
   return secret && (headerKey === secret || queryKey === secret);
 }
 
-// Expand/curate your seed queries here.
-// Keep them specific enough to stay under eBay's caps, broad enough to find inventory.
-const SEED_QUERIES = [
-  // Scotty Cameron
-  'scotty cameron newport 2 putter',
-  'scotty cameron newport putter',
-  'scotty cameron phantom 5 putter',
-  'scotty cameron phantom 7 putter',
-  'scotty cameron phantom 9 putter',
-  'scotty cameron phantom 11 putter',
-  'scotty cameron squareback putter',
-  'scotty cameron fastback putter',
-  'scotty cameron futura putter',
-  'scotty cameron button back putter',
-  'scotty cameron tei3 putter',
-  'scotty cameron studio select putter',
-  'scotty cameron studio style putter',
-  'scotty cameron special select putter',
-  'scotty cameron champions choice putter',
-  'scotty cameron jet set putter',
-  'scotty cameron newport beach putter',
-  'scotty cameron napa putter',
-  'scotty cameron circle t putter',
-
-  // Odyssey / Toulon
-  'odyssey two ball putter',
-  'odyssey eleven putter',
-  'odyssey seven putter',
-  'odyssey ten putter',
-  'odyssey versa putter',
-  'odyssey jailbird putter',
-  'odyssey white hot og putter',
-  'toulon atlanta putter',
-  'toulon memphis putter',
-  'toulon san diego putter',
-  'toulon las vegas putter',
-  'toulon garage putter',
-
-  // TaylorMade
-  'taylormade spider tour putter',
-  'taylormade spider x putter',
-  'taylormade spider gt putter',
-  'taylormade spider gtx putter',
-  'taylormade spider s putter',
-  'taylormade spider tour z putter',
-
-  // Ping
-  'ping anser putter',
-  'ping ds72 putter',
-  'ping tyne putter',
-
-  // LAB / Bettinardi / Evnroll / etc.
-  'lab golf mezz putter',
-  'lab golf df putter',
-  'lab golf link putter',
-  'bettinardi queen b putter',
-  'bettinardi studio stock putter',
-  'bettinardi bb putter',
-  'bettinardi inovai putter',
-  'evnroll er2 putter',
-  'evnroll er5 putter',
-  'mizuno m craft putter',
-  'wilson 8802 putter',
-  'sik putter',
-];
+// Seed queries are derived from the shared catalog so everything stays in sync.
+const SEED_QUERIES = PUTTER_SEED_QUERIES;
 
 // Small helpers to read price/shipping safely
 function readNumber(n) {


### PR DESCRIPTION
## Summary
- add lib/data/putterCatalog.js as the shared list of supported brand/model combinations
- derive the cron job seed queries from the catalog so the search surface stays in sync
- document how to maintain the catalog and confirm eBay API limits in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8b84a29588325ae15d4b1894326d3