### PR TITLE
Align sort mapping handling for putter listings

### DIFF
--- a/app/putters/page.js
+++ b/app/putters/page.js
@@ -181,6 +181,14 @@ const SORT_OPTIONS = [
   { label: "A → Z (Model)", value: "model_asc" },
 ];
 
+const sortParam = {
+  best_price_asc: "best_price_asc",
+  best_price_desc: "best_price_desc",
+  recent: "newlylisted",
+  model_asc: "model_asc",
+  count_desc: "count_desc",
+};
+
 const FIXED_PER_PAGE = 10;
 
 const retailerLogos = {
@@ -311,7 +319,11 @@ export default function PuttersPage() {
     if (sp.has("dex")) setDex(sp.get("dex") || "");
     if (sp.has("head")) setHead(sp.get("head") || "");
     if (sp.has("lengths")) setLengths(gNumList("lengths"));
-    if (sp.has("sort")) setSortBy(sp.get("sort") === "newlylisted" ? "recent" : "best_price_asc");
+    if (sp.has("sort")) {
+      const fromUrl = sp.get("sort");
+      const matched = Object.entries(sortParam).find(([, value]) => value === fromUrl);
+      if (matched) setSortBy(matched[0]);
+    }
     if (sp.has("group")) setGroupMode(sp.get("group") === "true");
     if (sp.has("broaden")) setBroaden(sp.get("broaden") === "true");
     if (sp.has("pro")) setIncludeProShops(sp.get("pro") === "true");
@@ -327,7 +339,7 @@ export default function PuttersPage() {
     if (maxPrice) params.set("maxPrice", String(maxPrice));
     if (conds.length) params.set("conditions", conds.join(","));
     if (buying.length) params.set("buyingOptions", buying.join(","));
-    if (sortBy === "recent") params.set("sort", "newlylisted");
+    if (sortParam[sortBy]) params.set("sort", sortParam[sortBy]);
     if (broaden) params.set("broaden", "true");
     if (dex) params.set("dex", dex);
     if (head) params.set("head", head);
@@ -350,7 +362,7 @@ export default function PuttersPage() {
     if (maxPrice) params.set("maxPrice", String(maxPrice));
     if (conds.length) params.set("conditions", conds.join(","));
     if (buying.length) params.set("buyingOptions", buying.join(","));
-    if (sortBy === "recent") params.set("sort", "newlylisted");
+    if (sortParam[sortBy]) params.set("sort", sortParam[sortBy]);
     if (broaden) params.set("broaden", "true");
     if (dex) params.set("dex", dex);
     if (includeProShops) params.set("pro","true");

--- a/pages/api/putters.js
+++ b/pages/api/putters.js
@@ -733,6 +733,8 @@ if (sort === "newlylisted") {
   });
 } else if (sort === "best_price_desc") {
   mergedOffers.sort((a, b) => (b.price ?? -Infinity) - (a.price ?? -Infinity));
+} else if (sort === "best_price_asc") {
+  mergedOffers.sort((a, b) => (a.price ?? Infinity) - (b.price ?? Infinity));
 } else if (sort === "model_asc") {
   // Use title as a proxy for model in flat view
   mergedOffers.sort((a, b) => (a.title || "").localeCompare(b.title || ""));
@@ -836,6 +838,8 @@ if (sort === "newlylisted") {
       });
     } else if (sort === "best_price_desc") {
       groups.sort((a, b) => (b.bestPrice ?? -Infinity) - (a.bestPrice ?? -Infinity));
+    } else if (sort === "best_price_asc") {
+      groups.sort((a, b) => (a.bestPrice ?? Infinity) - (b.bestPrice ?? Infinity));
     } else if (sort === "model_asc") {
       groups.sort((a, b) => (a.model || "").localeCompare(b.model || ""));
     } else if (sort === "count_desc") {


### PR DESCRIPTION
## Summary
- centralize sort parameter mapping in the putters page so URL sync and API requests align with the UI options
- treat the API route's best_price_asc sort as an explicit branch while leaving other sort behaviors untouched

## Testing
- npm run dev
- curl 'http://localhost:3000/api/putters?q=putter&sort=best_price_desc&page=1&perPage=5&group=false'

------
https://chatgpt.com/codex/tasks/task_e_68d8b8b5a06483258ec1f0f40a6cc582