### PR TITLE
Fix eBay bid count mapping for auctions

### DIFF
--- a/pages/api/putters.js
+++ b/pages/api/putters.js
@@ -569,7 +569,13 @@ export default async function handler(req, res) {
       const returnDays = item?.returnTerms?.returnPeriod?.value ? Number(item.returnTerms.returnPeriod.value) : null;
       const buying = {
         types: Array.isArray(item?.buyingOptions) ? item.buyingOptions : [],
-        bidCount: item?.bidCount != null ? Number(item.bidCount) : null,
+        bidCount: (() => {
+          const bidRaw =
+            item?.sellingStatus?.bidCount != null
+              ? item.sellingStatus.bidCount
+              : item?.bidCount;
+          return bidRaw != null ? safeNum(bidRaw) : null;
+        })(),
       };
 
       const specs = parseSpecsFromItem(item);


### PR DESCRIPTION
## Summary
- update the eBay offer mapping to read bid counts from the populated sellingStatus field
- keep the legacy bidCount fallback and coerce results to numeric values

## Testing
- Manual request of `/api/putters?q=<model>&hasBids=true` (blocked: missing eBay API credentials in local environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8c06431f88325bc49f002549309ac