### PR TITLE
Fix eBay bid count normalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
-    "start": "next start"
+    "start": "next start",
+    "test": "node --test pages/api/__tests__/*.test.js"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.0.1",

--- a/pages/api/__tests__/putters.test.js
+++ b/pages/api/__tests__/putters.test.js
@@ -1,0 +1,21 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { mapEbayItemToOffer } = require("../putters.js");
+
+test("legacy bidCount is honored by hasBids filter", () => {
+  const legacyOnlyItem = {
+    title: "Sample Putter",
+    price: { value: "199.99", currency: "USD" },
+    bidCount: "4",
+    buyingOptions: ["AUCTION"],
+    sellingStatus: {},
+  };
+
+  const offer = mapEbayItemToOffer(legacyOnlyItem);
+
+  assert.strictEqual(offer.buying.bidCount, 4);
+
+  const filtered = [offer].filter((o) => Number(o?.buying?.bidCount) > 0);
+  assert.strictEqual(filtered.length, 1);
+});

--- a/scripts/check-tokenize.mjs
+++ b/scripts/check-tokenize.mjs
@@ -1,4 +1,7 @@
-import { tokenize } from "../pages/api/putters.js";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { tokenize } = require("../pages/api/putters.js");
 
 const cases = [
   {


### PR DESCRIPTION
## Summary
- ensure numeric normalization handles null values and extract bid count mapping with a legacy-field fallback
- refactor the eBay offer mapper for reuse and expose it via CommonJS exports for testing
- add a regression test for legacy bid counts and wire up an npm test script while adjusting the tokenize script loader

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8c617f3348325989aa747feea945b