### PR TITLE
Normalize eBay bid count parsing

### DIFF
--- a/pages/api/__tests__/putters.test.js
+++ b/pages/api/__tests__/putters.test.js
@@ -1,0 +1,47 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+const modulePromise = import(pathToFileURL(path.join(__dirname, "..", "putters.js")).href);
+
+test("mapEbayItemToOffer normalizes bid count variants", async () => {
+  const { mapEbayItemToOffer } = await modulePromise;
+
+  const baseItem = {
+    title: "Test Putter",
+    price: { value: "199.99", currency: "USD" },
+    buyingOptions: ["AUCTION"],
+    shippingOptions: [],
+    itemSpecifics: [],
+    localizedAspects: [],
+    additionalProductIdentities: [],
+    seller: {},
+    returnTerms: {},
+    itemLocation: {},
+  };
+
+  const fixtures = [
+    {
+      desc: "sellingStatus array with string bidCount",
+      item: {
+        ...baseItem,
+        sellingStatus: [{ bidCount: ["4"] }],
+      },
+    },
+    {
+      desc: "sellingStatus object with __value__ wrapper",
+      item: {
+        ...baseItem,
+        sellingStatus: { bidCount: { __value__: "4" } },
+      },
+    },
+  ];
+
+  for (const { desc, item } of fixtures) {
+    const offer = mapEbayItemToOffer(item);
+    assert.equal(offer?.buying?.bidCount, 4, `${desc} → bidCount`);
+    const filtered = [offer].filter((o) => Number(o?.buying?.bidCount) > 0);
+    assert.equal(filtered.length, 1, `${desc} → hasBids filter retains offer`);
+  }
+});


### PR DESCRIPTION
## Summary
- add a bid count normalizer that unwraps array and __value__ wrappers before coercing to numbers
- reuse a shared `mapEbayItemToOffer` helper when mapping browse responses so nested bid counts surface in offers
- cover the array and __value__ bid count variants with node-based tests to ensure the hasBids filter keeps the offers

## Testing
- node --test pages/api/__tests__/putters.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d8c96ee7f48325af68f292f565eace