### PR TITLE
Refresh putter search page styling to match homepage

### DIFF
--- a/app/putters/page.js
+++ b/app/putters/page.js
@@ -445,986 +445,858 @@ export default function PuttersPage() {
       }
     }, 150);
 
-    return () => { ignore = true; clearTimeout(t); ctrl.abort(); };
-  }, [apiUrl, groupMode, sortBy, q]);
-
-  const sortedGroups = useMemo(() => {
-    const arr = [...groups];
-    if (sortBy === "best_price_asc") {
-      arr.sort((a,b) => (a.bestPrice ?? Infinity) - (b.bestPrice ?? Infinity));
-    } else if (sortBy === "best_price_desc") {
-      arr.sort((a,b) => (b.bestPrice ?? -Infinity) - (a.bestPrice ?? -Infinity));
-    } else if (sortBy === "count_desc") {
-      arr.sort((a,b) => (b.count ?? 0) - (a.count ?? 0));
-    } else if (sortBy === "model_asc") {
-      arr.sort((a,b) => (a.model || "").localeCompare(b.model || ""));
-    }
-    return arr;
-  }, [groups, sortBy]);
-
-  useEffect(() => {
-    const next = {};
-    sortedGroups.forEach((g) => { next[g.model] = false; });
-    setExpanded(next);
-  }, [sortedGroups.map((g) => g.model).join("|")]);
-
-  const toggleExpand = async (model) => {
-    setExpanded((prev) => ({ ...prev, [model]: !prev[model] }));
-    // When opening, load per-model analytics and stats if missing
-    const willOpen = !expanded[model];
-    if (willOpen) {
-      // mark as recently viewed when opening
-      pushRecent(model);
-
-      // lazily load lows/series/stats for this group
-      if (!lowsByModel[model]) {
-        try {
-          const r = await fetch(`/api/analytics/lows?model=${encodeURIComponent(model)}`, { cache: "no-store" });
-          const j = await r.json();
-          setLowsByModel((prev) => ({ ...prev, [model]: j?.lows || null }));
-        } catch {
-          setLowsByModel((prev) => ({ ...prev, [model]: { low1d: null, low7d: null, low30d: null } }));
-        }
-      }
-      if (!seriesByModel[model]) {
-        try {
-          const r = await fetch(`/api/analytics/series?model=${encodeURIComponent(model)}`, { cache: "no-store" });
-          const j = await r.json();
-          setSeriesByModel((prev) => ({ ...prev, [model]: j?.series || [] }));
-        } catch {
-          setSeriesByModel((prev) => ({ ...prev, [model]: [] }));
-        }
-      }
-      // Stats (condition-aware)
-      try {
-        const groupObj = groups.find((x) => x.model === model) || null;
-        const condParam = selectedConditionBand(conds) || inferConditionBandFromOffers(groupObj?.offers || []) || "";
-        const url = `/api/model-stats?model=${encodeURIComponent(model)}${condParam ? `&condition=${encodeURIComponent(condParam)}` : ""}`;
-        const statsKey = getStatsKey(model, condParam);
-        if (statsByModel[statsKey] === undefined) {
-          const r = await fetch(url, { cache: "no-store" });
-          const j = await r.json();
-          setStatsByModel((prev) => ({ ...prev, [statsKey]: j?.stats || null }));
-        }
-      } catch {
-        // ignore
-      }
-    }
-  };
-
-  const toggleShowAllOffers = (model) => setShowAllOffersByModel(prev => ({ ...prev, [model]: !prev[model] }));
-  const canPrev = hasPrev && page > 1 && !loading;
-  const canNext = hasNext && !loading;
-
-  function summarizeDexHead(g) {
-    const dexCounts = { LEFT: 0, RIGHT: 0 };
-    const headCounts = { BLADE: 0, MALLET: 0 };
-    const lenCounts = { 33: 0, 34: 0, 35: 0, 36: 0 };
-    for (const o of g.offers || []) {
-      const d = (o?.specs?.dexterity || "").toUpperCase();
-      const h = (o?.specs?.headType || "").toUpperCase();
-      if (d === "LEFT" || d === "RIGHT") dexCounts[d] += 1;
-      if (h === "BLADE" || h === "MALLET") headCounts[h] += 1;
-      const L = Number(o?.specs?.length);
-      if (Number.isFinite(L)) {
-        const nearest = [33,34,35,36].reduce((p,c) => Math.abs(c - L) < Math.abs(p - L) ? c : p, 34);
-        if (Math.abs(nearest - L) <= 0.5) lenCounts[nearest]++;
-      }
-    }
-    const domDex = dexCounts.LEFT === 0 && dexCounts.RIGHT === 0 ? null : (dexCounts.LEFT >= dexCounts.RIGHT ? "LEFT" : "RIGHT");
-    const domHead = headCounts.BLADE === 0 && headCounts.MALLET === 0 ? null : (headCounts.BLADE >= headCounts.MALLET ? "BLADE" : "MALLET");
-    const domLen = Object.entries(lenCounts).sort((a,b)=>b[1]-a[1])[0];
-    const domLenVal = domLen && domLen[1] > 0 ? Number(domLen[0]) : null;
-    return { domDex, domHead, domLen: domLenVal };
-  }
-
-  // quick “Great deal/Good deal” chip (kept for the summary row)
-  function fairPriceBadge(best, stats) {
-    if (!best || !stats) return null;
-    const p10 = Number(stats.p10), p50 = Number(stats.p50);
-    if (!isFinite(p10) && !isFinite(p50)) return null;
-    if (isFinite(p10) && best <= p10) return { label: "Great deal", tone: "emerald" };
-    if (isFinite(p50) && best <= p50) return { label: "Good deal", tone: "green" };
-    return null;
-  }
-
-  const clearAll = () => {
-    setQ(""); setOnlyComplete(true);
-    setMinPrice(""); setMaxPrice("");
-    setConds([]); setBuying([]); setHasBids(false);
-    setDex(""); setHead(""); setLengths([]);
-    setSortBy("best_price_asc");
-    setPage(1); setGroupMode(true); setBroaden(false);
-    setIncludeProShops(false);
-  };
-
-  /* ============================
-     FLAT VIEW: prefetch stats for visible items (variant + base)
-     ============================ */
-  useEffect(() => {
-    // Only run in flat/advanced mode when we have offers
-    if (!q.trim() || loading || err || groupMode || !showAdvanced) return;
-    if (!Array.isArray(offers) || offers.length === 0) return;
-
-    let abort = false;
-    const selCond = selectedConditionBand(conds) || "";
-    const seen = new Set();
-    const jobs = [];
-
-    for (const o of offers) {
-      const modelKey = getModelKey(o);
-      const condParam =
-        (o?.conditionBand || o?.condition || "").toUpperCase() ||
-        selCond ||
-        "";
-      const variant = detectVariant(o?.title);
-
-      // 1) Variant key first
-      if (variant) {
-        const vKey = getStatsKey3(modelKey, variant, condParam);
-        if (vKey && !statsByModel[vKey]) {
-          const vUrl =
-            `/api/model-stats?model=${encodeURIComponent(modelKey)}` +
-            `${condParam ? `&condition=${encodeURIComponent(condParam)}` : ""}` +
-            `&variant=${encodeURIComponent(variant)}`;
-
-          if (!seen.has(vUrl)) {
-            seen.add(vUrl);
-            jobs.push(
-              fetch(vUrl)
-                .then((r) => (r.ok ? r.json() : null))
-                .then((json) => {
-                  if (abort || !json) return;
-                  const stats = json?.stats ?? json;
-                  if (stats && Object.keys(stats).length) {
-                    setStatsByModel((prev) => ({ ...prev, [vKey]: stats }));
-                  }
-                })
-                .catch(() => {})
-            );
-          }
-        }
-      }
-
-      // 2) Base key fallback
-      const baseKey = getStatsKey(modelKey, condParam);
-      if (baseKey && !statsByModel[baseKey]) {
-        const baseUrl =
-          `/api/model-stats?model=${encodeURIComponent(modelKey)}` +
-          `${condParam ? `&condition=${encodeURIComponent(condParam)}` : ""}`;
-
-        if (!seen.has(baseUrl)) {
-          seen.add(baseUrl);
-          jobs.push(
-            fetch(baseUrl)
-              .then((r) => (r.ok ? r.json() : null))
-              .then((json) => {
-                if (abort || !json) return;
-                const stats = json?.stats ?? json;
-                if (stats && Object.keys(stats).length) {
-                  setStatsByModel((prev) => ({ ...prev, [baseKey]: stats }));
-                }
-              })
-              .catch(() => {})
-          );
-        }
-      }
-    }
-
-    if (jobs.length) {
-      Promise.all(jobs).catch(() => {});
-    }
-
-    return () => { abort = true; };
-  }, [q, loading, err, groupMode, showAdvanced, offers, JSON.stringify(conds)]);
+    const numberFormatter = useMemo(() => new Intl.NumberFormat("en-US"), []);
+  const trimmedQuery = q.trim();
+  const visibleCount = trimmedQuery ? (groupMode ? sortedGroups.length : offers.length) : 0;
+  const visibleLabel = groupMode ? "model groups" : "listings";
+  const formattedFetchedCount =
+    typeof fetchedCount === "number" ? numberFormatter.format(fetchedCount) : null;
+  const formattedKeptCount =
+    typeof keptCount === "number" ? numberFormatter.format(keptCount) : null;
+  const heroTitle = trimmedQuery
+    ? `Live market pulse for “${trimmedQuery}” putters.`
+    : "Compare putter prices in real time.";
+  const heroSubline = trimmedQuery
+    ? `Our bots are tracking ${formattedFetchedCount ? `${formattedFetchedCount} live` : "live"} listings${
+        formattedKeptCount ? ` and ranking ${formattedKeptCount} matches` : ""
+      } for “${trimmedQuery}” right now.`
+    : "Track eBay’s putter market with Smart Price intelligence tuned for golfers.";
+  const heroSupport = trimmedQuery
+    ? loading
+      ? "Refreshing the latest offers and recalculating Smart Price badges…"
+      : err
+      ? "We couldn’t refresh that feed just now — adjust filters or try again."
+      : `You’re viewing ${numberFormatter.format(visibleCount)} ${visibleLabel} with Smart Price badges updating on every refresh.`
+    : "Type a model or jump into a brand shortcut to watch deals surface in real time.";
+  const showResultsSummary = Boolean(trimmedQuery && !loading && !err);
+  const snapshotData = apiData?.analytics?.snapshot ?? null;
+  const hasSnapshot = Boolean(snapshotData?.price);
 
   return (
-    <main className="mx-auto max-w-6xl px-4 py-8">
-      <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <h1 className="text-3xl font-semibold tracking-tight">Compare Putter Prices</h1>
-          <p className="mt-1 text-sm text-gray-500">
-            Type a model (e.g., <em>“scotty cameron newport”</em>) or pick a brand.
-          </p>
-          <p className="mt-1 text-xs text-gray-500">
-            Badges based on recent comps. <a className="text-blue-600 underline" href="/methodology">See methodology</a>.
-          </p>
-        </div>
-        {q.trim() && (
-          <div className="text-sm text-gray-500">
-            {groupMode ? "Grouped by model" : "Flat list"} · Page{" "}
-            <span className="font-medium">{page}</span> ·{" "}
-            <span className="font-medium">{FIXED_PER_PAGE}</span>{" "}
-            {groupMode ? "groups" : "listings"}
-          </div>
-        )}
-      </header>
-
-      {/* Recently viewed */}
-      {recent.length > 0 && (
-        <section className="mt-4 flex flex-wrap items-center gap-2">
-          <span className="text-xs uppercase tracking-wide text-gray-500">Recently viewed:</span>
-          {recent.map((m) => (
-            <button
-              key={m}
-              onClick={() => setQ(m)}
-              className="rounded-full border border-gray-300 px-3 py-1 text-sm hover:bg-gray-100"
-              title={`Search ${m}`}
+    <main className="min-h-screen bg-slate-950 text-white">
+      <section className="relative isolate overflow-hidden px-6 py-20 sm:py-24">
+        <div className="mx-auto max-w-5xl text-center">
+          <span className="inline-flex items-center rounded-full bg-emerald-500/10 px-4 py-1 text-sm font-semibold text-emerald-200 ring-1 ring-inset ring-emerald-400/30">
+            Live eBay market intelligence
+          </span>
+          <h1 className="mt-6 text-4xl font-bold tracking-tight sm:text-5xl">{heroTitle}</h1>
+          <p className="mt-6 text-lg leading-8 text-slate-200">{heroSubline}</p>
+          <p className="mt-3 text-sm text-emerald-200">{heroSupport}</p>
+          <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+            <a
+              href="#search-controls"
+              className="inline-flex items-center justify-center rounded-full bg-emerald-500 px-6 py-3 text-base font-semibold text-slate-950 shadow-lg shadow-emerald-500/40 transition hover:bg-emerald-400"
             >
-              {m}
-            </button>
-          ))}
-          <button
-            onClick={clearRecent}
-            className="ml-2 rounded-full border border-gray-200 px-2 py-0.5 text-xs text-gray-500 hover:bg-gray-50"
-          >
-            clear
-          </button>
-        </section>
-      )}
-
-      {/* Brand shortcuts */}
-      <section className="mt-6 flex flex-wrap gap-2">
-        {BRANDS.map((b) => (
-          <button
-            key={b.label}
-            onClick={() => setQ(b.q)}
-            className="rounded-full border border-gray-300 px-3 py-1 text-sm hover:bg-gray-100"
-            title={`Search ${b.label}`}
-          >
-            {b.label}
-          </button>
-        ))}
-      </section>
-
-      {/* Top controls */}
-      <section className="mt-6 grid grid-cols-1 gap-3 md:grid-cols-5">
-        <div className="md:col-span-2">
-          <label className="mb-1 block text-sm font-medium">Search</label>
-          <input
-            type="text"
-            value={q}
-            onChange={(e) => setQ(e.target.value)}
-            placeholder="e.g. scotty cameron newport"
-            className="w-full rounded-md border border-gray-300 px-3 py-2 outline-none focus:ring-2 focus:ring-blue-500"
-          />
-        </div>
-
-        <div>
-          <label className="mb-1 block text-sm font-medium">Sort</label>
-          <select
-            value={sortBy}
-            onChange={(e) => setSortBy(e.target.value)}
-            className="w-full rounded-md border border-gray-300 px-3 py-2"
-          >
-            {SORT_OPTIONS.map((s) => (
-              <option key={s.value} value={s.value}>{s.label}</option>
-            ))}
-          </select>
-        </div>
-
-        <div className="rounded-md border border-gray-200 p-3">
-          <label className="flex items-center gap-2 text-sm">
-            <input type="checkbox" checked={broaden} onChange={(e) => setBroaden(e.target.checked)} />
-            Broaden search (include common variants)
-          </label>
-          <p className="mt-1 text-xs text-gray-500">
-            Pulls more pages from eBay before filtering. Helpful for niche models/years.
+              Refine this search
+            </a>
+            <a
+              href={trimmedQuery ? "#results" : "#brand-shortcuts"}
+              className="inline-flex items-center justify-center rounded-full bg-white/10 px-6 py-3 text-base font-semibold text-white ring-1 ring-inset ring-white/20 transition hover:bg-white/20"
+            >
+              {trimmedQuery ? "Jump to live results" : "Browse brand shortcuts"}
+            </a>
+          </div>
+          <p className="mt-3 text-xs uppercase tracking-wide text-slate-300/80">
+            Smart Price badges update with every refresh — tap a card to inspect live offers.
           </p>
         </div>
-	<div className="rounded-md border border-gray-200 p-3">
-  <label className="flex items-center gap-2 text-sm">
-    <input
-      type="checkbox"
-      checked={includeProShops}
-      onChange={(e) => setIncludeProShops(e.target.checked)}
-    />
-    Include pro-shop sites (2nd Swing – beta)
-  </label>
-  <p className="mt-1 text-xs text-gray-500">
-    Adds 2nd Swing listings when enabled.
-  </p>
-</div>
-
-
-        <div className="flex items-end justify-between gap-3">
-          <button onClick={clearAll} className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm hover:bg-gray-100">
-            Clear
-          </button>
-        </div>
       </section>
 
-      {/* Filters */}
-      <section className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-5">
-        {/* Quality */}
-        <div className="rounded-lg border border-gray-200 p-4">
-          <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-600">Quality</h3>
-          <label className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={onlyComplete}
-              onChange={(e) => setOnlyComplete(e.target.checked)}
-            />
-            Only show listings with price & image
-          </label>
-        </div>
-
-        {/* Price */}
-        <div className="rounded-lg border border-gray-200 p-4">
-          <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-600">Price</h3>
-          <div className="flex items-center gap-2">
-            <input
-              type="number"
-              min="0"
-              placeholder="Min"
-              value={minPrice}
-              onChange={(e) => setMinPrice(e.target.value)}
-              className="w-full rounded-md border border-gray-300 px-2 py-1"
-            />
-            <span className="text-gray-400">—</span>
-            <input
-              type="number"
-              min="0"
-              placeholder="Max"
-              value={maxPrice}
-              onChange={(e) => setMaxPrice(e.target.value)}
-              className="w-full rounded-md border border-gray-300 px-2 py-1"
-            />
-          </div>
-        </div>
-
-        {/* Condition */}
-        <div className="rounded-lg border border-gray-200 p-4">
-          <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-600">Condition</h3>
-          <div className="flex flex-col gap-2">
-            {CONDITION_OPTIONS.map((c) => (
-              <label key={c.value} className="flex items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={conds.includes(c.value)}
-                  onChange={() =>
-                    setConds((prev) =>
-                      prev.includes(c.value)
-                        ? prev.filter((v) => v !== c.value)
-                        : [...prev, c.value]
-                    )
-                  }
-                />
-                {c.label}
-              </label>
-            ))}
-          </div>
-        </div>
-
-        {/* Dexterity */}
-        <div className="rounded-lg border border-gray-200 p-4">
-          <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-600">Dexterity</h3>
-          <div className="flex flex-col gap-2 text-sm">
-            <label className="flex items-center gap-2">
-              <input
-                type="radio"
-                name="dex"
-                checked={dex === ""}
-                onChange={() => setDex("")}
-              />
-              Any
-            </label>
-            <label className="flex items-center gap-2">
-              <input
-                type="radio"
-                name="dex"
-                checked={dex === "RIGHT"}
-                onChange={() => setDex("RIGHT")}
-              />
-              Right-handed
-            </label>
-            <label className="flex items-center gap-2">
-              <input
-                type="radio"
-                name="dex"
-                checked={dex === "LEFT"}
-                onChange={() => setDex("LEFT")}
-              />
-              Left-handed
-            </label>
-          </div>
-        </div>
-
-        {/* Head Type */}
-        <div className="rounded-lg border border-gray-200 p-4">
-          <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-600">Head Type</h3>
-          <div className="flex flex-col gap-2 text-sm">
-            <label className="flex items-center gap-2">
-              <input
-                type="radio"
-                name="head"
-                checked={head === ""}
-                onChange={() => setHead("")}
-              />
-              Any
-            </label>
-            <label className="flex items-center gap-2">
-              <input
-                type="radio"
-                name="head"
-                checked={head === "BLADE"}
-                onChange={() => setHead("BLADE")}
-              />
-              Blade
-            </label>
-            <label className="flex items-center gap-2">
-              <input
-                type="radio"
-                name="head"
-                checked={head === "MALLET"}
-                onChange={() => setHead("MALLET")}
-              />
-              Mallet
-            </label>
-          </div>
-        </div>
-
-        {/* Length (common) */}
-        <div className="rounded-lg border border-gray-200 p-4 md:col-span-2">
-          <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-600">Length (common)</h3>
-          <div className="flex flex-wrap gap-3 text-sm">
-            {[33,34,35,36].map(L => (
-              <label key={L} className="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={lengths.includes(L)}
-                  onChange={() => {
-                    setLengths(prev => prev.includes(L) ? prev.filter(x => x !== L) : [...prev, L]);
-                  }}
-                />
-                {L}&quot;
-              </label>
-            ))}
-            <div className="text-xs text-gray-500 basis-full">
-              We match titles within ±0.5&quot; of the selected length(s).
+      <section id="search-controls" className="bg-white px-6 py-16 text-slate-900 sm:py-20">
+        <div className="mx-auto max-w-6xl space-y-8">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="max-w-3xl">
+              <h2 className="text-2xl font-semibold tracking-tight text-slate-900 sm:text-3xl">
+                Dial in your live putter feed
+              </h2>
+              <p className="mt-2 text-sm text-slate-600">
+                Badges are benchmarked against recent comps.&nbsp;
+                <a className="font-semibold text-emerald-600 hover:text-emerald-500" href="/methodology">
+                  See methodology
+                </a>
+                .
+              </p>
             </div>
-          </div>
-        </div>
-
-        {/* Buying Options + Advanced */}
-        <div className="rounded-lg border border-gray-200 p-4 md:col-span-3">
-          <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-gray-600">Buying Options</h3>
-          <div className="flex flex-wrap gap-3">
-            {BUYING_OPTIONS.map((b) => (
-              <label key={b.value} className="flex items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={buying.includes(b.value)}
-                  onChange={() =>
-                    setBuying((prev) =>
-                      prev.includes(b.value)
-                        ? prev.filter((v) => v !== b.value)
-                        : [...prev, b.value]
-                    )
-                  }
-                />
-                {b.label}
-              </label>
-            ))}
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={hasBids}
-                onChange={(e) => setHasBids(e.target.checked)}
-              />
-              Has bids
-            </label>
-          </div>
-
-          <div className="mt-4">
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={showAdvanced}
-                onChange={(e) => setShowAdvanced(e.target.checked)}
-              />
-              Show advanced options
-            </label>
-
-            {showAdvanced && (
-              <label className="mt-3 flex items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={groupMode}
-                  onChange={(e) => setGroupMode(e.target.checked)}
-                />
-                Group similar listings (model cards)
-              </label>
+            {trimmedQuery && (
+              <div className="text-sm text-slate-500">
+                {groupMode ? "Grouped by model" : "Flat list"} · Page{" "}
+                <span className="font-semibold text-slate-900">{page}</span> ·{" "}
+                <span className="font-semibold text-slate-900">{FIXED_PER_PAGE}</span> {groupMode ? "groups" : "listings"}
+              </div>
             )}
           </div>
+
+          {recent.length > 0 && (
+            <section className="flex flex-wrap items-center gap-2 rounded-2xl border border-slate-200 bg-slate-50/60 px-4 py-3">
+              <span className="text-xs uppercase tracking-wide text-slate-500">Recently viewed:</span>
+              {recent.map((m) => (
+                <button
+                  key={m}
+                  onClick={() => setQ(m)}
+                  className="rounded-full border border-slate-200 bg-white px-3 py-1 text-sm font-medium text-slate-900 transition hover:bg-slate-100"
+                  title={`Search ${m}`}
+                >
+                  {m}
+                </button>
+              ))}
+              <button
+                onClick={clearRecent}
+                className="ml-2 rounded-full border border-slate-200 bg-white px-2 py-0.5 text-xs font-medium text-slate-500 transition hover:bg-slate-100"
+              >
+                clear
+              </button>
+            </section>
+          )}
+
+          <section id="brand-shortcuts" className="flex flex-wrap gap-2">
+            {BRANDS.map((b) => (
+              <button
+                key={b.label}
+                onClick={() => setQ(b.q)}
+                className="rounded-full border border-slate-200 bg-white px-4 py-1.5 text-sm font-medium text-slate-900 transition hover:bg-slate-100"
+                title={`Search ${b.label}`}
+              >
+                {b.label}
+              </button>
+            ))}
+          </section>
+
+          <section className="grid grid-cols-1 gap-4 md:grid-cols-6">
+            <div className="md:col-span-2">
+              <label className="mb-2 block text-sm font-semibold text-slate-700">Search</label>
+              <input
+                type="text"
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="e.g. scotty cameron newport"
+                className="w-full rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-base text-slate-900 outline-none transition focus:ring-2 focus:ring-emerald-400"
+              />
+            </div>
+
+            <div>
+              <label className="mb-2 block text-sm font-semibold text-slate-700">Sort</label>
+              <select
+                value={sortBy}
+                onChange={(e) => setSortBy(e.target.value)}
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm font-medium text-slate-900 transition focus:ring-2 focus:ring-emerald-400"
+              >
+                {SORT_OPTIONS.map((s) => (
+                  <option key={s.value} value={s.value}>
+                    {s.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <label className="flex items-start gap-2 text-sm font-medium text-slate-700">
+                <input type="checkbox" checked={broaden} onChange={(e) => setBroaden(e.target.checked)} />
+                <span>
+                  Broaden search (include common variants)
+                  <span className="mt-1 block text-xs font-normal text-slate-500">
+                    Pulls more pages from eBay before filtering. Helpful for niche models/years.
+                  </span>
+                </span>
+              </label>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <label className="flex items-start gap-2 text-sm font-medium text-slate-700">
+                <input
+                  type="checkbox"
+                  checked={includeProShops}
+                  onChange={(e) => setIncludeProShops(e.target.checked)}
+                />
+                <span>
+                  Include pro-shop sites (2nd Swing – beta)
+                  <span className="mt-1 block text-xs font-normal text-slate-500">
+                    Adds 2nd Swing listings when enabled.
+                  </span>
+                </span>
+              </label>
+            </div>
+
+            <div className="flex items-end">
+              <button
+                onClick={clearAll}
+                className="w-full rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100"
+              >
+                Clear
+              </button>
+            </div>
+          </section>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-5">
+            <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Quality</h3>
+              <label className="flex items-center gap-2 text-sm text-slate-700">
+                <input
+                  type="checkbox"
+                  checked={onlyComplete}
+                  onChange={(e) => setOnlyComplete(e.target.checked)}
+                />
+                Only show listings with price &amp; image
+              </label>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Price</h3>
+              <div className="flex items-center gap-2">
+                <input
+                  type="number"
+                  min="0"
+                  placeholder="Min"
+                  value={minPrice}
+                  onChange={(e) => setMinPrice(e.target.value)}
+                  className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:ring-2 focus:ring-emerald-400"
+                />
+                <span className="text-slate-400">—</span>
+                <input
+                  type="number"
+                  min="0"
+                  placeholder="Max"
+                  value={maxPrice}
+                  onChange={(e) => setMaxPrice(e.target.value)}
+                  className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none transition focus:ring-2 focus:ring-emerald-400"
+                />
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Condition</h3>
+              <div className="flex flex-col gap-2">
+                {CONDITION_OPTIONS.map((c) => (
+                  <label key={c.value} className="flex items-center gap-2 text-sm text-slate-700">
+                    <input
+                      type="checkbox"
+                      checked={conds.includes(c.value)}
+                      onChange={() =>
+                        setConds((prev) =>
+                          prev.includes(c.value)
+                            ? prev.filter((v) => v !== c.value)
+                            : [...prev, c.value]
+                        )
+                      }
+                    />
+                    {c.label}
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Dexterity</h3>
+              <div className="flex flex-col gap-2 text-sm text-slate-700">
+                <label className="flex items-center gap-2">
+                  <input type="radio" name="dex" checked={dex === ""} onChange={() => setDex("")} />
+                  Any
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    name="dex"
+                    checked={dex === "RIGHT"}
+                    onChange={() => setDex("RIGHT")}
+                  />
+                  Right-handed
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    name="dex"
+                    checked={dex === "LEFT"}
+                    onChange={() => setDex("LEFT")}
+                  />
+                  Left-handed
+                </label>
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Head Type</h3>
+              <div className="flex flex-col gap-2 text-sm text-slate-700">
+                <label className="flex items-center gap-2">
+                  <input type="radio" name="head" checked={head === ""} onChange={() => setHead("")} />
+                  Any
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    name="head"
+                    checked={head === "BLADE"}
+                    onChange={() => setHead("BLADE")}
+                  />
+                  Blade
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    name="head"
+                    checked={head === "MALLET"}
+                    onChange={() => setHead("MALLET")}
+                  />
+                  Mallet
+                </label>
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm md:col-span-2">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Length (common)
+              </h3>
+              <div className="flex flex-wrap gap-3 text-sm text-slate-700">
+                {[33, 34, 35, 36].map((L) => (
+                  <label key={L} className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={lengths.includes(L)}
+                      onChange={() => {
+                        setLengths((prev) => (prev.includes(L) ? prev.filter((x) => x !== L) : [...prev, L]));
+                      }}
+                    />
+                    {L}&quot;
+                  </label>
+                ))}
+                <div className="basis-full text-xs text-slate-500">
+                  We match titles within ±0.5&quot; of the selected length(s).
+                </div>
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm md:col-span-3">
+              <h3 className="mb-3 text-xs font-semibold uppercase tracking-wide text-slate-500">Buying Options</h3>
+              <div className="flex flex-wrap gap-3 text-sm text-slate-700">
+                {BUYING_OPTIONS.map((b) => (
+                  <label key={b.value} className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={buying.includes(b.value)}
+                      onChange={() =>
+                        setBuying((prev) =>
+                          prev.includes(b.value)
+                            ? prev.filter((v) => v !== b.value)
+                            : [...prev, b.value]
+                        )
+                      }
+                    />
+                    {b.label}
+                  </label>
+                ))}
+                <label className="flex items-center gap-2">
+                  <input type="checkbox" checked={hasBids} onChange={(e) => setHasBids(e.target.checked)} />
+                  Has bids
+                </label>
+              </div>
+
+              <div className="mt-4 space-y-3 text-sm text-slate-700">
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={showAdvanced}
+                    onChange={(e) => setShowAdvanced(e.target.checked)}
+                  />
+                  Show advanced options
+                </label>
+
+                {showAdvanced && (
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={groupMode}
+                      onChange={(e) => setGroupMode(e.target.checked)}
+                    />
+                    Group similar listings (model cards)
+                  </label>
+                )}
+              </div>
+            </div>
+          </div>
         </div>
       </section>
 
-      {!q.trim() && (
-        <div className="mt-8 rounded-md border border-gray-200 bg-white p-6 text-center text-sm text-gray-600">
-          Start by typing a putter model or choose a brand above to see grouped price comparisons.
-        </div>
-      )}
-
-      {q.trim() && !loading && !err && (
-        <div className="mt-2 text-sm text-gray-600">
-          Showing{" "}
-          <span className="font-medium">{groupMode ? groups?.length ?? 0 : offers?.length ?? 0}</span>{" "}
-          {groupMode ? "model groups" : "listings"}
-          {typeof keptCount === "number" && typeof fetchedCount === "number" ? (
-            <> from <span className="font-medium">{keptCount}</span> kept (fetched {fetchedCount}).</>
-          ) : null}
-        </div>
-      )}
-
-      {/* LIVE analytics snapshot */}
-      <MarketSnapshot snapshot={apiData?.analytics?.snapshot} meta={apiData?.meta} query={q} />
-
-      {/* Loading & error UI */}
-      {q.trim() && loading && (
-        <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-2">
-          {Array.from({ length: Math.min(FIXED_PER_PAGE, 6) }).map((_, i) => (
-            <div key={i} className="animate-pulse overflow-hidden rounded-xl border border-gray-200 bg-white">
-              <div className="h-40 bg-gray-100" />
-              <div className="space-y-3 p-4">
-                <div className="h-4 w-1/2 rounded bg-gray-200" />
-                <div className="h-3 w-1/3 rounded bg-gray-200" />
-                <div className="h-8 w-full rounded bg-gray-100" />
-              </div>
+      <section id="results" className="bg-slate-100 px-6 py-16 text-slate-900 sm:py-20">
+        <div className="mx-auto max-w-6xl">
+          {!trimmedQuery && (
+            <div className="rounded-3xl border border-slate-200 bg-white p-8 text-center text-sm text-slate-600">
+              Start by typing a putter model or choose a brand above to see grouped price comparisons.
             </div>
-          ))}
-        </div>
-      )}
-      {q.trim() && err && (
-        <div className="mt-6 rounded-md border border-red-200 bg-red-50 p-4">
-          <p className="text-sm text-red-700">{err}</p>
-        </div>
-      )}
+          )}
 
-      {/* GROUPED VIEW */}
-      {q.trim() && !loading && !err && groupMode && (
-        <>
-          <section className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-2">
-            {sortedGroups.map((g) => {
-              const isOpen = !!expanded[g.model];
+          {showResultsSummary && (
+            <div className="text-sm text-slate-600">
+              Showing <span className="font-semibold text-slate-900">{numberFormatter.format(visibleCount)}</span>{" "}
+              {visibleLabel}
+              {typeof keptCount === "number" && typeof fetchedCount === "number" ? (
+                <>
+                  {" "}from <span className="font-semibold text-slate-900">{numberFormatter.format(keptCount)}</span> kept (fetched {numberFormatter.format(fetchedCount)}).
+                </>
+              ) : null}
+            </div>
+          )}
 
-              const ordered =
-                sortBy === "best_price_desc"
-                  ? [...g.offers].sort((a,b) => (b.price ?? -Infinity) - (a.price ?? -Infinity))
-                  : [...g.offers].sort((a,b) => (a.price ?? Infinity) - (b.price ?? Infinity));
+          {hasSnapshot && (
+            <div className="mt-10 rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm backdrop-blur">
+              <MarketSnapshot snapshot={snapshotData} meta={apiData?.meta} query={q} />
+            </div>
+          )}
 
-              const nums = ordered.map(o => o?.price).filter(x => typeof x === "number").sort((a,b)=>a-b);
-              const nNums = nums.length;
-              const med = nNums < 2 ? null : (nNums % 2 ? nums[Math.floor(nNums/2)] : (nums[nNums/2-1]+nums[nNums/2])/2);
-              const bestDelta = (typeof g.bestPrice === "number" && typeof med === "number" && med - g.bestPrice > 0)
-                ? { diff: med - g.bestPrice, pct: ((med - g.bestPrice)/med)*100 }
-                : null;
-
-              const { domDex, domHead, domLen } = summarizeDexHead(g);
-
-              const showAll = !!showAllOffersByModel[g.model];
-              const list = isOpen ? (showAll ? ordered : ordered.slice(0, 10)) : [];
-
-              const lows = lowsByModel[g.model];
-              const series = seriesByModel[g.model] || [];
-              const groupCond = selectedConditionBand(conds) || inferConditionBandFromOffers(g?.offers || []) || "";
-              const statsKey = getStatsKey(g.model, groupCond);
-              const stats = statsByModel[statsKey] || null;
-
-              const firstOffer = ordered[0];
-              const bestUrl = firstOffer?.url ?? null;
-
-              const helperModelKey = firstOffer ? getModelKey(firstOffer) : g.model;
-              const helperVariant = firstOffer ? detectVariant(firstOffer?.title) : null;
-              const helperVariantKey = getStatsKey3(helperModelKey, helperVariant, groupCond);
-              const helperBaseKey = getStatsKey(helperModelKey, groupCond);
-              const helperVariantStats = statsByModel[helperVariantKey] ?? null;
-              const helperBaseStats = statsByModel[helperBaseKey] ?? stats;
-
-              const fair = fairPriceBadge(g.bestPrice, stats);
-
-              return (
-                <article key={g.model} className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-                  <div className="relative aspect-[4/3] w-full max-h-48 bg-gray-50">
-                    {g.image ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img src={g.image} alt={g.model} className="h-full w-full object-contain" loading="lazy" />
-                    ) : (
-                      <div className="flex h-full w-full items-center justify-center text-xs text-gray-400">
-                        No image
-                      </div>
-                    )}
+          {trimmedQuery && loading && (
+            <div className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-2">
+              {Array.from({ length: Math.min(FIXED_PER_PAGE, 6) }).map((_, i) => (
+                <div
+                  key={i}
+                  className="animate-pulse overflow-hidden rounded-3xl border border-slate-200 bg-white"
+                >
+                  <div className="h-40 bg-slate-100" />
+                  <div className="space-y-3 p-5">
+                    <div className="h-4 w-1/2 rounded bg-slate-200" />
+                    <div className="h-3 w-1/3 rounded bg-slate-200" />
+                    <div className="h-8 w-full rounded bg-slate-100" />
                   </div>
+                </div>
+              ))}
+            </div>
+          )}
 
-                  <div className="p-4">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <h3 className="text-lg font-semibold leading-tight">{g.model}</h3>
-                        <p className="mt-1 text-xs text-gray-500">
-                          {g.count} offer{g.count === 1 ? "" : "s"} · {g.retailers.join(", ")}
-                        </p>
+          {err && (
+            <div className="mt-10 rounded-3xl border border-red-200 bg-red-50/80 p-6 text-sm text-red-700">
+              {err}
+            </div>
+          )}
 
-                        {/* Dominant chips + BADGES */}
-                        <div className="mt-2 flex flex-wrap items-center gap-2">
-                          {domDex && (
-                            <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-700">
-                              {domDex === "LEFT" ? "Left-hand" : "Right-hand"}
-                            </span>
-                          )}
-                          {domHead && (
-                            <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-[11px] font-medium text-indigo-700">
-                              {domHead === "MALLET" ? "Mallet" : "Blade"}
-                            </span>
-                          )}
-                          {Number.isFinite(domLen) && (
-                            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-800">
-                              ~{domLen}&quot;
-                            </span>
-                          )}
+          {trimmedQuery && !loading && !err && groupMode && (
+            <>
+              <section className="mt-10 space-y-6">
+                {sortedGroups.map((g) => {
+                  const isOpen = !!expanded[g.model];
+                  const ordered =
+                    sortBy === "best_price_desc"
+                      ? [...(g.offers || [])].sort((a, b) => (b.price ?? -Infinity) - (a.price ?? -Infinity))
+                      : [...(g.offers || [])].sort((a, b) => (a.price ?? Infinity) - (b.price ?? Infinity));
+                  const nums = ordered
+                    .map((o) => o?.price)
+                    .filter((x) => typeof x === "number")
+                    .sort((a, b) => a - b);
+                  const nNums = nums.length;
+                  const med =
+                    nNums < 2
+                      ? null
+                      : nNums % 2
+                      ? nums[Math.floor(nNums / 2)]
+                      : (nums[nNums / 2 - 1] + nums[nNums / 2]) / 2;
+                  const bestDelta =
+                    typeof g.bestPrice === "number" && typeof med === "number" && med - g.bestPrice > 0
+                      ? { diff: med - g.bestPrice, pct: ((med - g.bestPrice) / med) * 100, med }
+                      : null;
+                  const { domDex, domHead, domLen } = summarizeDexHead(g);
+                  const showAll = !!showAllOffersByModel[g.model];
+                  const list = isOpen ? (showAll ? ordered : ordered.slice(0, 10)) : [];
+                  const lows = lowsByModel[g.model];
+                  const series = seriesByModel[g.model] || [];
+                  const groupCond = selectedConditionBand(conds) || inferConditionBandFromOffers(g?.offers || []) || "";
+                  const statsKey = getStatsKey(g.model, groupCond);
+                  const stats = statsByModel[statsKey] || null;
+                  const firstOffer = ordered[0];
+                  const bestUrl = firstOffer?.url ?? null;
+                  const helperModelKey = firstOffer ? getModelKey(firstOffer) : g.model;
+                  const helperVariant = firstOffer ? detectVariant(firstOffer?.title) : null;
+                  const helperVariantKey = getStatsKey3(helperModelKey, helperVariant, groupCond);
+                  const helperBaseKey = getStatsKey(helperModelKey, groupCond);
+                  const helperVariantStats = statsByModel[helperVariantKey] ?? null;
+                  const helperBaseStats = statsByModel[helperBaseKey] ?? stats;
+                  const fair = fairPriceBadge(g.bestPrice, stats);
 
-                          {/* Group header price badge */}
-                          <SmartPriceBadge
-                            price={Number(g.bestPrice)}
-                            baseStats={helperBaseStats}
-                            variantStats={helperVariantStats}
-                            className="ml-1"
-                          />
-
-                          {/* Optional quick chip */}
-                          {fair && (
-                            <span className={`rounded-full px-2 py-0.5 text-[11px] font-medium text-white ${fair.tone === "emerald" ? "bg-emerald-600" : "bg-green-600"}`}>
-                              {fair.label}
-                            </span>
-                          )}
-                        </div>
-
-                        {/* Helper badge (variant-aware from first listing) */}
-                        <div className="mt-2">
-                          <SmartPriceBadge
-                            price={Number(g.bestPrice)}
-                            baseStats={helperBaseStats}
-                            variantStats={helperVariantStats}
-                            title={firstOffer?.title || g.model}
-                            specs={firstOffer?.specs}
-                            brand={g?.brand}
-                            showHelper
-                          />
-                        </div>
-
-                        {/* Lows row (on expand) */}
-                        {isOpen && (
-                          <div className="mt-2 text-xs text-gray-600">
-                            <span className="mr-2">Lows:</span>
-                            <span className="mr-3">1d {formatPrice(Number(lows?.low1d))}</span>
-                            <span className="mr-3">7d {formatPrice(Number(lows?.low7d))}</span>
-                            <span>30d {formatPrice(Number(lows?.low30d))}</span>
+                  return (
+                    <article
+                      key={g.model}
+                      className="overflow-hidden rounded-3xl border border-slate-200 bg-white p-6 shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+                    >
+                      <div className="relative aspect-[4/3] w-full max-h-48 overflow-hidden rounded-2xl bg-slate-100">
+                        {g.image ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img src={g.image} alt={g.model} className="h-full w-full object-contain" loading="lazy" />
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center text-xs text-slate-500">
+                            Live data populates images as we refresh listings.
                           </div>
                         )}
                       </div>
 
-                      <div className="flex flex-col items-end gap-1">
-                        <div className="shrink-0 rounded-full bg-green-100 px-3 py-1 text-xs font-semibold text-green-700">
-                          Best: {formatPrice(g.bestPrice, g.bestCurrency)}
-                        </div>
-                        {bestDelta && (
-                          <div
-                            className="rounded-full bg-emerald-50 px-3 py-1 text-[11px] font-medium text-emerald-700"
-                            title={`Median ${formatPrice(med)} · Save ~${formatPrice(bestDelta.diff)} (~${bestDelta.pct.toFixed(0)}%)`}
-                          >
-                            Save {formatPrice(bestDelta.diff)} (~{bestDelta.pct.toFixed(0)}%)
-                          </div>
-                        )}
+                      <div className="mt-6 flex flex-col gap-4">
+                        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                          <div className="min-w-0 flex-1">
+                            <h3 className="text-xl font-semibold text-slate-900">{g.model}</h3>
+                            <p className="mt-1 text-xs text-slate-500">
+                              {g.count} offer{g.count === 1 ? "" : "s"} · {g.retailers.join(", ")}
+                            </p>
 
-                        {/* Copy best link */}
-                        <button
-                          disabled={!bestUrl}
-                          onClick={async () => {
-                            if (!bestUrl) return;
-                            await copyToClipboard(bestUrl);
-                            setCopiedFor(g.model);
-                            setTimeout(() => setCopiedFor((c) => (c === g.model ? "" : c)), 1500);
-                          }}
-                          className={`mt-1 rounded-md border px-2 py-1 text-[11px] ${bestUrl ? "hover:bg-gray-50" : "opacity-50 cursor-not-allowed"}`}
-                          title="Copy best listing link"
-                        >
-                          {copiedFor === g.model ? "Copied!" : "Copy best"}
-                        </button>
-                      </div>
-                    </div>
-
-                    {/* Sparkline */}
-                    {isOpen && Array.isArray(series) && series.length > 1 && (
-                      <div className="mt-3">
-                        <PriceSparkline data={series} height={70} showAverage showMedian className="h-[70px]" />
-                      </div>
-                    )}
-
-                    <div className="mt-4 flex gap-2">
-                      <button
-                        onClick={() => toggleExpand(g.model)}
-                        className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm hover:bg-gray-50"
-                      >
-                        {isOpen ? "Hide offers" : `View offers (${g.count})`}
-                      </button>
-                      {isOpen && g.count > 10 && (
-                        <button
-                          onClick={() => toggleShowAllOffers(g.model)}
-                          className="rounded-md border border-gray-300 px-3 py-2 text-sm hover:bg-gray-50"
-                        >
-                          {showAll ? "Show top 10" : "Show all"}
-                        </button>
-                      )}
-                    </div>
-
-                    {/* Expanded listings */}
-                    {isOpen && (
-                      <ul className="mt-3 space-y-2">
-                        {list.map((o) => {
-                          const condParam =
-                            (o?.conditionBand || o?.condition || "").toUpperCase() ||
-                            selectedConditionBand(conds) ||
-                            "";
-
-                          // Variant-aware stats lookup
-                          const modelKey   = getModelKey(o);
-                          const variant    = detectVariant(o?.title);
-                          const variantKey = getStatsKey3(modelKey, variant, condParam);
-                          const baseKey    = getStatsKey(modelKey, condParam);
-                          const variantStats = statsByModel[variantKey] ?? null;
-                          const baseStats = statsByModel[baseKey] ?? stats;
-
-                          return (
-                            <li
-                              key={o.productId + o.url}
-                              className="flex items-center justify-between gap-3 rounded border border-gray-100 p-2"
-                            >
-                              {/* LEFT: logo + retailer/seller */}
-                              <div className="flex min-w-0 items-center gap-2">
-                                {retailerLogos[o.retailer] && (
-                                  // eslint-disable-next-line @next/next/no-img-element
-                                  <img
-                                    src={retailerLogos[o.retailer]}
-                                    alt={o.retailer}
-                                    className="h-4 w-12 object-contain"
-                                  />
-                                )}
-
-                                <div className="min-w-0">
-                                  <div className="truncate text-sm font-medium">
-                                    {o.retailer}
-                                    {o?.seller?.username && (
-                                      <span className="ml-2 text-xs text-gray-500">@{o.seller.username}</span>
-                                    )}
-                                    {typeof o?.seller?.feedbackPct === "number" && (
-                                      <span className="ml-2 rounded-full bg-gray-100 px-2 py-[2px] text-[11px] font-medium text-gray-700">
-                                        {o.seller.feedbackPct.toFixed(1)}%
-                                      </span>
-                                    )}
-                                    {Number(o?.buying?.bidCount) > 0 && (
-                                      <span className="ml-2 text-xs font-medium text-amber-600">
-                                        · {o.buying.bidCount} bids
-                                      </span>
-                                    )}
-                                  </div>
-
-                                  {/* Enhanced spec line */}
-                                  <div className="mt-0.5 truncate text-xs text-gray-500">
-                                    {(o.specs?.dexterity || "").toUpperCase() === "LEFT" ? "LH" :
-                                     (o.specs?.dexterity || "").toUpperCase() === "RIGHT" ? "RH" : "—"}
-                                    {" · "}
-                                    {(o.specs?.headType || "").toUpperCase() || "—"}
-                                    {" · "}
-                                    {Number.isFinite(Number(o?.specs?.length)) ? `${o.specs.length}"` : "—"}
-                                    {o?.specs?.shaft && <> · {String(o.specs.shaft).toLowerCase()}</>}
-                                    {o?.specs?.hosel && <> · {o.specs.hosel}</>}
-                                    {o?.specs?.face && <> · {o.specs.face}</>}
-                                    {o?.specs?.grip && <> · {o.specs.grip}</>}
-                                    {o?.specs?.hasHeadcover && <> · HC</>}
-                                    {o?.specs?.toeHang && <> · {o.specs.toeHang} toe</>}
-                                    {Number.isFinite(Number(o?.specs?.loft)) && <> · {o.specs.loft}° loft</>}
-                                    {Number.isFinite(Number(o?.specs?.lie)) && <> · {o.specs.lie}° lie</>}
-                                    {o.createdAt && (<> · listed {timeAgo(new Date(o.createdAt).getTime())}</>)}
-                                  </div>
-                                </div>
-                              </div>
-
-                              {/* RIGHT: badge + price + view */}
-                              <div className="flex items-center gap-3">
-                                <SmartPriceBadge
-                                  price={Number(o.price)}
-                                  baseStats={baseStats}
-                                  variantStats={variantStats}
-                                  title={o.title}
-                                  specs={o.specs}
-                                  brand={g?.brand}
-                                />
-                                <span className="text-sm font-semibold">
-                                  {typeof o.price === "number" ? formatPrice(o.price, o.currency) : "—"}
+                            <div className="mt-3 flex flex-wrap items-center gap-2">
+                              {domDex && (
+                                <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-medium text-slate-700">
+                                  {domDex === "LEFT" ? "Left-hand" : "Right-hand"}
                                 </span>
-                                <a
-                                  href={o.url}
-                                  target="_blank"
-                                  rel="noreferrer"
-                                  className="rounded-md border px-2 py-1 text-xs"
+                              )}
+                              {domHead && (
+                                <span className="rounded-full bg-indigo-100 px-2 py-0.5 text-[11px] font-medium text-indigo-700">
+                                  {domHead === "MALLET" ? "Mallet" : "Blade"}
+                                </span>
+                              )}
+                              {Number.isFinite(domLen) && (
+                                <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[11px] font-medium text-amber-800">
+                                  ~{domLen}&quot;
+                                </span>
+                              )}
+
+                              <SmartPriceBadge
+                                price={Number(g.bestPrice)}
+                                baseStats={helperBaseStats}
+                                variantStats={helperVariantStats}
+                                className="ml-1"
+                              />
+
+                              {fair && (
+                                <span
+                                  className={`rounded-full px-2 py-0.5 text-[11px] font-medium text-white ${
+                                    fair.tone === "emerald" ? "bg-emerald-600" : "bg-green-600"
+                                  }`}
                                 >
-                                  View
-                                </a>
+                                  {fair.label}
+                                </span>
+                              )}
+                            </div>
+
+                            <div className="mt-3">
+                              <SmartPriceBadge
+                                price={Number(g.bestPrice)}
+                                baseStats={helperBaseStats}
+                                variantStats={helperVariantStats}
+                                title={firstOffer?.title || g.model}
+                                specs={firstOffer?.specs}
+                                brand={g?.brand}
+                                showHelper
+                              />
+                            </div>
+
+                            {isOpen && (
+                              <div className="mt-3 text-xs text-slate-600">
+                                <span className="mr-2">Lows:</span>
+                                <span className="mr-3">1d {formatPrice(Number(lows?.low1d))}</span>
+                                <span className="mr-3">7d {formatPrice(Number(lows?.low7d))}</span>
+                                <span>30d {formatPrice(Number(lows?.low30d))}</span>
                               </div>
-                            </li>
-                          );
-                        })}
+                            )}
+                          </div>
 
-                        {!showAll && g.count > 10 && (
-                          <li className="px-2 pt-1 text-xs text-gray-500">Showing top 10 offers.</li>
-                        )}
-                      </ul>
-                    )}
-                  </div>
-                </article>
-              );
-            })}
-          </section>
-
-          {/* Pagination (grouped) */}
-          <div className="mt-8 flex items-center justify-between">
-            <button
-              disabled={!canPrev}
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
-              className={`rounded-md border px-3 py-2 text-sm ${canPrev ? "hover:bg-gray-100" : "cursor-not-allowed opacity-50"}`}
-            >
-              ← Prev
-            </button>
-            <div className="text-sm text-gray-600">
-              Page <span className="font-medium">{page}</span> · {FIXED_PER_PAGE} groups per page
-            </div>
-            <button
-              disabled={!canNext}
-              onClick={() => setPage((p) => p + 1)}
-              className={`rounded-md border px-3 py-2 text-sm ${canNext ? "hover:bg-gray-100" : "cursor-not-allowed opacity-50"}`}
-            >
-              Next →
-            </button>
-          </div>
-        </>
-      )}
-
-      {/* FLAT VIEW (advanced) */}
-      {q.trim() && !loading && !err && !groupMode && showAdvanced && (
-        <>
-          <section className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {offers.map((o) => {
-              const modelKey = getModelKey(o);
-              const condParam =
-                (o?.conditionBand || o?.condition || "").toUpperCase() ||
-                selectedConditionBand(conds) ||
-                "";
-              const variant    = detectVariant(o?.title);
-              const variantKey = getStatsKey3(modelKey, variant, condParam);
-              const baseKey    = getStatsKey(modelKey, condParam);
-              const variantStats = statsByModel[variantKey] ?? null;
-              const baseStats    = statsByModel[baseKey] ?? null;
-              const stats        = variantStats ?? baseStats;
-
-              return (
-                <article key={o.productId + o.url} className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-                  <div className="relative aspect-[4/3] w-full bg-gray-50">
-                    {o.image ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img src={o.image} alt={o.title} className="h-full w-full object-contain" loading="lazy" />
-                    ) : (
-                      <div className="flex h-full w-full items-center justify-center text-xs text-gray-400">No image</div>
-                    )}
-                  </div>
-                  <div className="p-4">
-                    <h3 className="line-clamp-2 text-sm font-semibold">{o.title}</h3>
-                    <p className="mt-1 text-xs text-gray-500">
-                      {o?.seller?.username && <>@{o.seller.username} · </>}
-                      {typeof o?.seller?.feedbackPct === "number" && <>{o.seller.feedbackPct.toFixed(1)}% · </>}
-                      {Number(o?.buying?.bidCount) > 0 && <>{o.buying.bidCount} bids · </>}
-                      {(o.specs?.dexterity || "").toUpperCase() || "—"} · {(o.specs?.headType || "").toUpperCase() || "—"} ·
-                      {Number.isFinite(Number(o?.specs?.length)) ? `${o.specs.length}"` : "—"}
-                      {o?.specs?.shaft && <> · {String(o.specs.shaft).toLowerCase()}</>}
-                      {o?.specs?.hosel && <> · {o.specs.hosel}</>}
-                      {o?.specs?.face && <> · {o.specs.face}</>}
-                      {o?.specs?.grip && <> · {o.specs.grip}</>}
-                      {o?.specs?.hasHeadcover && <> · HC</>}
-                      {o?.specs?.toeHang && <> · {o.specs.toeHang} toe</>}
-                      {Number.isFinite(Number(o?.specs?.loft)) && <> · {o.specs.loft}° loft</>}
-                      {Number.isFinite(Number(o?.specs?.lie)) && <> · {o.specs.lie}° lie</>}
-                      {o.createdAt && (<> · listed {timeAgo(new Date(o.createdAt).getTime())}</>)}
-                    </p>
-
-                    <div className="mt-3 flex items-center justify-between">
-                      <div className="flex items-center gap-2">
-                        <SmartPriceBadge
-                          price={Number(o.price)}
-                          baseStats={baseStats}
-                          variantStats={variantStats}
-                          title={o.title}
-                          specs={o.specs}
-                          brand={o.brand || ""}
-                          className="mr-2"
-                        />
-
-                        <span className="text-base font-semibold">{formatPrice(o.price, o.currency)}</span>
-
-                        {/* Optional Save $ chip if below median */}
-                        {(() => {
-                          const p50 = stats?.p50;
-                          if (Number.isFinite(Number(p50)) && typeof o.price === "number" && o.price < Number(p50)) {
-                            const save = Number(p50) - o.price;
-                            const pct = Math.round((save / Number(p50)) * 100);
-                            return (
-                              <span
-                                className="rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700"
-                                title={`Median ${formatPrice(Number(p50))} · Save ~${formatPrice(save)} (~${pct}%)`}
+                          <div className="flex shrink-0 flex-col items-end gap-2">
+                            <div className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-700">
+                              Best: {formatPrice(g.bestPrice, g.bestCurrency)}
+                            </div>
+                            {bestDelta && (
+                              <div
+                                className="rounded-full bg-emerald-100 px-3 py-1 text-[11px] font-medium text-emerald-700"
+                                title={`Median ${formatPrice(bestDelta.med)} · Save ~${formatPrice(bestDelta.diff)} (~${bestDelta.pct.toFixed(0)}%)`}
                               >
-                                Save {formatPrice(save)}
-                              </span>
-                            );
-                          }
-                          return null;
-                        })()}
+                                Save {formatPrice(bestDelta.diff)} (~{bestDelta.pct.toFixed(0)}%)
+                              </div>
+                            )}
+
+                            <button
+                              disabled={!bestUrl}
+                              onClick={async () => {
+                                if (!bestUrl) return;
+                                await copyToClipboard(bestUrl);
+                                setCopiedFor(g.model);
+                                setTimeout(() => setCopiedFor((c) => (c === g.model ? "" : c)), 1500);
+                              }}
+                              className={`mt-1 rounded-full border border-slate-200 px-3 py-1 text-[11px] font-medium text-slate-700 transition ${
+                                bestUrl ? "hover:bg-slate-100" : "cursor-not-allowed opacity-50"
+                              }`}
+                              title="Copy best listing link"
+                            >
+                              {copiedFor === g.model ? "Copied!" : "Copy best"}
+                            </button>
+                          </div>
+                        </div>
+
+                        {isOpen && Array.isArray(series) && series.length > 1 && (
+                          <div className="rounded-2xl bg-slate-50/80 p-4">
+                            <PriceSparkline data={series} height={70} showAverage showMedian className="h-[70px]" />
+                          </div>
+                        )}
+
+                        <div className="flex flex-wrap gap-3">
+                          <button
+                            onClick={() => toggleExpand(g.model)}
+                            className="inline-flex flex-1 items-center justify-center rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 shadow-sm transition hover:bg-emerald-400"
+                          >
+                            {isOpen ? "Hide offers" : `View offers (${g.count})`}
+                          </button>
+                          {isOpen && g.count > 10 && (
+                            <button
+                              onClick={() => toggleShowAllOffers(g.model)}
+                              className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100"
+                            >
+                              {showAll ? "Show top 10" : "Show all"}
+                            </button>
+                          )}
+                        </div>
+
+                        {isOpen && (
+                          <ul className="mt-4 space-y-2">
+                            {list.map((o) => {
+                              const condParam =
+                                (o?.conditionBand || o?.condition || "").toUpperCase() ||
+                                selectedConditionBand(conds) ||
+                                "";
+                              const modelKey = getModelKey(o);
+                              const variant = detectVariant(o?.title);
+                              const variantKey = getStatsKey3(modelKey, variant, condParam);
+                              const baseKey = getStatsKey(modelKey, condParam);
+                              const variantStats = statsByModel[variantKey] ?? null;
+                              const baseStats = statsByModel[baseKey] ?? stats;
+
+                              return (
+                                <li
+                                  key={o.productId + o.url}
+                                  className="flex items-center justify-between gap-3 rounded-2xl border border-slate-100 bg-slate-50/70 p-3"
+                                >
+                                  <div className="flex min-w-0 items-center gap-3">
+                                    {retailerLogos[o.retailer] && (
+                                      // eslint-disable-next-line @next/next/no-img-element
+                                      <img
+                                        src={retailerLogos[o.retailer]}
+                                        alt={o.retailer}
+                                        className="h-4 w-12 object-contain"
+                                      />
+                                    )}
+
+                                    <div className="min-w-0">
+                                      <div className="truncate text-sm font-semibold text-slate-900">
+                                        {o.retailer}
+                                        {o?.seller?.username && (
+                                          <span className="ml-2 text-xs font-normal text-slate-500">@{o.seller.username}</span>
+                                        )}
+                                        {typeof o?.seller?.feedbackPct === "number" && (
+                                          <span className="ml-2 rounded-full bg-slate-100 px-2 py-[2px] text-[11px] font-medium text-slate-700">
+                                            {o.seller.feedbackPct.toFixed(1)}%
+                                          </span>
+                                        )}
+                                        {Number(o?.buying?.bidCount) > 0 && (
+                                          <span className="ml-2 text-xs font-medium text-amber-600">· {o.buying.bidCount} bids</span>
+                                        )}
+                                      </div>
+
+                                      <div className="mt-1 truncate text-xs text-slate-500">
+                                        {(o.specs?.dexterity || "").toUpperCase() === "LEFT"
+                                          ? "LH"
+                                          : (o.specs?.dexterity || "").toUpperCase() === "RIGHT"
+                                          ? "RH"
+                                          : "—"}
+                                        {" · "}
+                                        {(o.specs?.headType || "").toUpperCase() || "—"}
+                                        {" · "}
+                                        {Number.isFinite(Number(o?.specs?.length)) ? `${o.specs.length}"` : "—"}
+                                        {o?.specs?.shaft && <> · {String(o.specs.shaft).toLowerCase()}</>}
+                                        {o?.specs?.hosel && <> · {o.specs.hosel}</>}
+                                        {o?.specs?.face && <> · {o.specs.face}</>}
+                                        {o?.specs?.grip && <> · {o.specs.grip}</>}
+                                        {o?.specs?.hasHeadcover && <> · HC</>}
+                                        {o?.specs?.toeHang && <> · {o.specs.toeHang} toe</>}
+                                        {Number.isFinite(Number(o?.specs?.loft)) && <> · {o.specs.loft}° loft</>}
+                                        {Number.isFinite(Number(o?.specs?.lie)) && <> · {o.specs.lie}° lie</>}
+                                        {o.createdAt && <> · listed {timeAgo(new Date(o.createdAt).getTime())}</>}
+                                      </div>
+                                    </div>
+                                  </div>
+
+                                  <div className="flex flex-wrap items-center justify-end gap-3">
+                                    <SmartPriceBadge
+                                      price={Number(o.price)}
+                                      baseStats={baseStats}
+                                      variantStats={variantStats}
+                                      title={o.title}
+                                      specs={o.specs}
+                                      brand={g?.brand}
+                                    />
+                                    <span className="text-sm font-semibold text-slate-900">
+                                      {typeof o.price === "number" ? formatPrice(o.price, o.currency) : "—"}
+                                    </span>
+                                    <a
+                                      href={o.url}
+                                      target="_blank"
+                                      rel="noreferrer"
+                                      className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1.5 text-xs font-semibold text-slate-950 shadow-sm transition hover:bg-emerald-400"
+                                    >
+                                      View
+                                    </a>
+                                  </div>
+                                </li>
+                              );
+                            })}
+
+                            {!showAll && g.count > 10 && (
+                              <li className="px-3 pt-1 text-xs text-slate-500">Showing top 10 offers.</li>
+                            )}
+                          </ul>
+                        )}
                       </div>
+                    </article>
+                  );
+                })}
+              </section>
 
-                      {/* Affiliate/outbound link UNCHANGED */}
-                      <a
-                        href={o.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700"
-                      >
-                        View
-                      </a>
-                    </div>
-                  </div>
-                </article>
-              );
-            })}
-          </section>
+              <div className="mt-10 flex items-center justify-between gap-4">
+                <button
+                  disabled={!canPrev}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  className={`rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold transition ${
+                    canPrev ? "bg-white text-slate-700 hover:bg-slate-100" : "cursor-not-allowed bg-white/60 text-slate-400"
+                  }`}
+                >
+                  ← Prev
+                </button>
+                <div className="text-sm text-slate-600">
+                  Page <span className="font-semibold text-slate-900">{page}</span> · {FIXED_PER_PAGE} groups per page
+                </div>
+                <button
+                  disabled={!canNext}
+                  onClick={() => setPage((p) => p + 1)}
+                  className={`rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold transition ${
+                    canNext ? "bg-white text-slate-700 hover:bg-slate-100" : "cursor-not-allowed bg-white/60 text-slate-400"
+                  }`}
+                >
+                  Next →
+                </button>
+              </div>
+            </>
+          )}
 
-          {/* Pagination (flat) */}
-          <div className="mt-8 flex items-center justify-between">
-            <button
-              disabled={!hasPrev || page <= 1 || loading}
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
-              className={`rounded-md border px-3 py-2 text-sm ${hasPrev && page > 1 && !loading ? "hover:bg-gray-100" : "cursor-not-allowed opacity-50"}`}
-            >
-              ← Prev
-            </button>
-            <div className="text-sm text-gray-600">
-              Page <span className="font-medium">{page}</span> · {FIXED_PER_PAGE} listings per page
-            </div>
-            <button
-              disabled={!hasNext || loading}
-              onClick={() => setPage((p) => p + 1)}
-              className={`rounded-md border px-3 py-2 text-sm ${hasNext && !loading ? "hover:bg-gray-100" : "cursor-not-allowed opacity-50"}`}
-            >
-              Next →
-            </button>
-          </div>
-        </>
-      )}
+          {trimmedQuery && !loading && !err && !groupMode && showAdvanced && (
+            <>
+              <section className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {offers.map((o) => {
+                  const modelKey = getModelKey(o);
+                  const condParam =
+                    (o?.conditionBand || o?.condition || "").toUpperCase() ||
+                    selectedConditionBand(conds) ||
+                    "";
+                  const variant = detectVariant(o?.title);
+                  const variantKey = getStatsKey3(modelKey, variant, condParam);
+                  const baseKey = getStatsKey(modelKey, condParam);
+                  const variantStats = statsByModel[variantKey] ?? null;
+                  const baseStats = statsByModel[baseKey] ?? null;
+                  const stats = variantStats ?? baseStats;
+
+                  return (
+                    <article
+                      key={o.productId + o.url}
+                      className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-lg"
+                    >
+                      <div className="relative aspect-[4/3] w-full bg-slate-100">
+                        {o.image ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img src={o.image} alt={o.title} className="h-full w-full object-contain" loading="lazy" />
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center text-xs text-slate-500">No image</div>
+                        )}
+                      </div>
+                      <div className="flex flex-col gap-4 p-5">
+                        <div>
+                          <h3 className="line-clamp-2 text-sm font-semibold text-slate-900">{o.title}</h3>
+                          <p className="mt-2 text-xs text-slate-500">
+                            {o?.seller?.username && <>@{o.seller.username} · </>}
+                            {typeof o?.seller?.feedbackPct === "number" && <>{o.seller.feedbackPct.toFixed(1)}% · </>}
+                            {Number(o?.buying?.bidCount) > 0 && <>{o.buying.bidCount} bids · </>}
+                            {(o.specs?.dexterity || "").toUpperCase() || "—"} · {(o.specs?.headType || "").toUpperCase() || "—"} ·
+                            {Number.isFinite(Number(o?.specs?.length)) ? `${o.specs.length}"` : "—"}
+                            {o?.specs?.shaft && <> · {String(o.specs.shaft).toLowerCase()}</>}
+                            {o?.specs?.hosel && <> · {o.specs.hosel}</>}
+                            {o?.specs?.face && <> · {o.specs.face}</>}
+                            {o?.specs?.grip && <> · {o.specs.grip}</>}
+                            {o?.specs?.hasHeadcover && <> · HC</>}
+                            {o?.specs?.toeHang && <> · {o.specs.toeHang} toe</>}
+                            {Number.isFinite(Number(o?.specs?.loft)) && <> · {o.specs.loft}° loft</>}
+                            {Number.isFinite(Number(o?.specs?.lie)) && <> · {o.specs.lie}° lie</>}
+                            {o.createdAt && <> · listed {timeAgo(new Date(o.createdAt).getTime())}</>}
+                          </p>
+                        </div>
+
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <SmartPriceBadge
+                              price={Number(o.price)}
+                              baseStats={baseStats}
+                              variantStats={variantStats}
+                              title={o.title}
+                              specs={o.specs}
+                              brand={o.brand || ""}
+                              className="mr-2"
+                            />
+
+                            <span className="text-base font-semibold text-slate-900">
+                              {formatPrice(o.price, o.currency)}
+                            </span>
+
+                            {(() => {
+                              const p50 = stats?.p50;
+                              if (Number.isFinite(Number(p50)) && typeof o.price === "number" && o.price < Number(p50)) {
+                                const save = Number(p50) - o.price;
+                                const pct = Math.round((save / Number(p50)) * 100);
+                                return (
+                                  <span
+                                    className="rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-medium text-emerald-700"
+                                    title={`Median ${formatPrice(Number(p50))} · Save ~${formatPrice(save)} (~${pct}%)`}
+                                  >
+                                    Save {formatPrice(save)}
+                                  </span>
+                                );
+                              }
+                              return null;
+                            })()}
+                          </div>
+
+                          <a
+                            href={o.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-flex items-center rounded-full bg-emerald-500 px-3 py-1.5 text-sm font-semibold text-slate-950 shadow-sm transition hover:bg-emerald-400"
+                          >
+                            View
+                          </a>
+                        </div>
+                      </div>
+                    </article>
+                  );
+                })}
+              </section>
+
+              <div className="mt-10 flex items-center justify-between gap-4">
+                <button
+                  disabled={!canPrev}
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  className={`rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold transition ${
+                    canPrev ? "bg-white text-slate-700 hover:bg-slate-100" : "cursor-not-allowed bg-white/60 text-slate-400"
+                  }`}
+                >
+                  ← Prev
+                </button>
+                <div className="text-sm text-slate-600">
+                  Page <span className="font-semibold text-slate-900">{page}</span> · {FIXED_PER_PAGE} listings per page
+                </div>
+                <button
+                  disabled={!canNext}
+                  onClick={() => setPage((p) => p + 1)}
+                  className={`rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold transition ${
+                    canNext ? "bg-white text-slate-700 hover:bg-slate-100" : "cursor-not-allowed bg-white/60 text-slate-400"
+                  }`}
+                >
+                  Next →
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Rebuilt the putter search page hero with the dark homepage styling and dynamic copy that reflects the current query state.
- Moved the search inputs, brand shortcuts, and filters into a white control band with updated slate/emerald accents for visual consistency.
- Restyled grouped and flat result cards, analytics panels, and pagination to use the rounded card treatments and emerald calls to action from the homepage.

## Testing
- `npm run lint` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8cf863ec483258e73052b39272cb2