### PR TITLE
Add Callaway support to catalog and brand detection

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -30,6 +30,7 @@ const BRAND_PATTERNS = [
   { key: "Ping", pattern: /\bping\b/i },
   { key: "Odyssey", pattern: /odyssey/i },
   { key: "Bettinardi", pattern: /bettinardi/i },
+  { key: "Callaway", pattern: /callaway/i },
   { key: "L.A.B. Golf", pattern: /\blab\b|lie\s*angle\s*balance/i },
   { key: "Evnroll", pattern: /evnroll/i },
   { key: "Mizuno", pattern: /mizuno/i },

--- a/lib/data/putterCatalog.js
+++ b/lib/data/putterCatalog.js
@@ -11,6 +11,11 @@ export const PUTTER_CATALOG = [
   { brand: 'Bettinardi', model: 'Hive' },
   { brand: 'Bettinardi', model: 'DASS' },
 
+  // Callaway
+  { brand: 'Callaway', model: 'Apex' },
+  { brand: 'Callaway', model: 'Rogue' },
+  { brand: 'Callaway', model: 'X Forged' },
+
   // Cleveland
   { brand: 'Cleveland', model: 'Frontline' },
   { brand: 'Cleveland', model: 'Huntington Beach' },


### PR DESCRIPTION
## Summary
- add Callaway Apex, Rogue, and X Forged families to the shared putter catalog
- ensure homepage brand detection recognizes Callaway listings via a regex matcher

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d964b6b6b08325bf04ca5b165e2815