### PR TITLE
Support model-targeted putter queries

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -577,28 +577,36 @@ export default async function Home() {
             </p>
           </div>
           <div className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-            {trending.map((item) => (
-              <div key={item.modelKey} className="flex flex-col rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-                <p className="text-sm uppercase tracking-wide text-slate-500">Trending search</p>
-                <h3 className="mt-2 text-xl font-semibold text-slate-900">{item.label || "Model updating"}</h3>
-                <p className="mt-2 text-sm text-slate-600">
-                  {item.count > 0
-                    ? `${item.count.toLocaleString()} recent listings tracked`
-                    : "Pulling market counts…"}
-                </p>
-                <div className="mt-6">
-                  <Link
-                    href={`/putters?q=${encodeURIComponent(item.query)}`}
-                    className="inline-flex items-center rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-slate-950 shadow-sm transition hover:bg-emerald-400"
-                  >
-                    Explore this model
-                  </Link>
-                  <p className="mt-2 text-xs text-emerald-600">
-                    We send you to the best eBay listing with verified savings.
+            {trending.map((item) => {
+              const params = new URLSearchParams();
+              if (item.query) params.set("q", item.query);
+              if (item.modelKey) params.set("modelKey", item.modelKey);
+              const qs = params.toString();
+              const href = qs ? `/putters?${qs}` : "/putters";
+
+              return (
+                <div key={item.modelKey} className="flex flex-col rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+                  <p className="text-sm uppercase tracking-wide text-slate-500">Trending search</p>
+                  <h3 className="mt-2 text-xl font-semibold text-slate-900">{item.label || "Model updating"}</h3>
+                  <p className="mt-2 text-sm text-slate-600">
+                    {item.count > 0
+                      ? `${item.count.toLocaleString()} recent listings tracked`
+                      : "Pulling market counts…"}
                   </p>
+                  <div className="mt-6">
+                    <Link
+                      href={href}
+                      className="inline-flex items-center rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-slate-950 shadow-sm transition hover:bg-emerald-400"
+                    >
+                      Explore this model
+                    </Link>
+                    <p className="mt-2 text-xs text-emerald-600">
+                      We send you to the best eBay listing with verified savings.
+                    </p>
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
       </SectionWrapper>
 

--- a/app/putters/page.js
+++ b/app/putters/page.js
@@ -278,7 +278,8 @@ export default function PuttersPage() {
   const [sortBy, setSortBy] = useState("best_price_asc");
   const [page, setPage] = useState(1);
   const [q, setQ] = useState("");
-  const [broaden, setBroaden] = useState(false); 
+  const [modelKeyParam, setModelKeyParam] = useState("");
+  const [broaden, setBroaden] = useState(false);
   const [includeProShops, setIncludeProShops] = useState(false);
 
 
@@ -333,6 +334,13 @@ export default function PuttersPage() {
     if (sp.has("broaden")) setBroaden(sp.get("broaden") === "true");
     if (sp.has("pro")) setIncludeProShops(sp.get("pro") === "true");
     if (sp.has("page")) setPage(Math.max(1, Number(sp.get("page") || "1")));
+    if (sp.has("modelKey")) {
+      const fromUrlModel = (sp.get("modelKey") || "").trim();
+      setModelKeyParam(fromUrlModel);
+    } else if (sp.has("model")) {
+      const fromUrlModel = (sp.get("model") || "").trim();
+      setModelKeyParam(fromUrlModel);
+    }
   }, []);
 
   // reflect state → URL
@@ -351,13 +359,20 @@ export default function PuttersPage() {
     if (head) params.set("head", head);
     if (lengths.length) params.set("lengths", lengths.join(","));
     if (includeProShops) params.set("pro","true");
+    if (modelKeyParam.trim()) params.set("modelKey", modelKeyParam.trim());
     params.set("page", String(page));
     params.set("group", groupMode ? "true" : "false");
 
     const qs = params.toString();
     const url = qs ? `/putters?${qs}` : "/putters";
     window.history.replaceState({}, "", url);
-  }, [q, onlyComplete, minPrice, maxPrice, conds, buying, hasBids, sortBy, page, groupMode, broaden, dex, head, lengths, includeProShops]);
+  }, [q, onlyComplete, minPrice, maxPrice, conds, buying, hasBids, sortBy, page, groupMode, broaden, dex, head, lengths, includeProShops, modelKeyParam]);
+
+  useEffect(() => {
+    if (!q.trim() && modelKeyParam) {
+      setModelKeyParam("");
+    }
+  }, [q, modelKeyParam]);
 
   // API URL
   const apiUrl = useMemo(() => {
@@ -375,18 +390,19 @@ export default function PuttersPage() {
     if (includeProShops) params.set("pro","true");
     if (head) params.set("head", head);
     if (lengths.length) params.set("lengths", lengths.join(","));
+    if (modelKeyParam.trim()) params.set("modelKey", modelKeyParam.trim());
     params.set("page", String(page));
     params.set("perPage", String(FIXED_PER_PAGE));
     params.set("group", groupMode ? "true" : "false");
     params.set("samplePages", "3");
     params.set("_ts", String(Date.now()));
     return `/api/putters?${params.toString()}`;
-  }, [q, onlyComplete, minPrice, maxPrice, conds, buying, hasBids, sortBy, page, groupMode, broaden, dex, head, lengths, includeProShops]);
+  }, [q, onlyComplete, minPrice, maxPrice, conds, buying, hasBids, sortBy, page, groupMode, broaden, dex, head, lengths, includeProShops, modelKeyParam]);
 
   // Reset to page 1 when inputs change
   useEffect(() => {
     setPage(1);
-  }, [q, onlyComplete, minPrice, maxPrice, conds, buying, hasBids, sortBy, groupMode, broaden, dex, head, lengths, includeProShops]);
+  }, [q, onlyComplete, minPrice, maxPrice, conds, buying, hasBids, sortBy, groupMode, broaden, dex, head, lengths, includeProShops, modelKeyParam]);
 
   // Fetch results
   useEffect(() => {


### PR DESCRIPTION
## Summary
- allow `/api/putters` to accept an optional `modelKey` parameter and relax the strict title token guard by including normalized model tokens for targeted deep links.
- propagate the `modelKey` parameter through the `/putters` page state so deep links trigger the expanded matching while keeping the URL synchronized.
- add the `modelKey` query param to homepage trending links to keep deep links aligned with tracked models.

## Testing
- npm run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ac9078e88325bf2fa6bd348ea4d4