### PR TITLE
Update tour putter source citation

### DIFF
--- a/lib/data/tourPutters2024.js
+++ b/lib/data/tourPutters2024.js
@@ -3,47 +3,50 @@
 // Keep modelKey values aligned with items.model_key (lowercase, brand stripped) so
 // the background collectors continue writing price snapshots for these entries.
 
+export const DATAGOLF_WHATS_IN_THE_BAG_URL =
+  'https://www.datagolf.com/whats-in-the-bag';
+
 export const TOUR_PUTTERS_2024 = [
   {
     modelKey: 'newport 2',
     displayName: 'Scotty Cameron Newport 2',
     usageRank: 1,
     playerCount: 38,
-    sourceUrl: 'https://www.datagolf.com/tools/whats-in-the-bag?club=putter',
+    sourceUrl: DATAGOLF_WHATS_IN_THE_BAG_URL,
   },
   {
     modelKey: 'spider tour',
     displayName: 'TaylorMade Spider Tour',
     usageRank: 2,
     playerCount: 21,
-    sourceUrl: 'https://www.datagolf.com/tools/whats-in-the-bag?club=putter',
+    sourceUrl: DATAGOLF_WHATS_IN_THE_BAG_URL,
   },
   {
     modelKey: 'jailbird',
     displayName: 'Odyssey Jailbird',
     usageRank: 3,
     playerCount: 17,
-    sourceUrl: 'https://www.datagolf.com/tools/whats-in-the-bag?club=putter',
+    sourceUrl: DATAGOLF_WHATS_IN_THE_BAG_URL,
   },
   {
     modelKey: 'ds72',
     displayName: 'Ping DS72',
     usageRank: 4,
     playerCount: 15,
-    sourceUrl: 'https://www.datagolf.com/tools/whats-in-the-bag?club=putter',
+    sourceUrl: DATAGOLF_WHATS_IN_THE_BAG_URL,
   },
   {
     modelKey: 'queen b',
     displayName: 'Bettinardi Queen B',
     usageRank: 5,
     playerCount: 12,
-    sourceUrl: 'https://www.datagolf.com/tools/whats-in-the-bag?club=putter',
+    sourceUrl: DATAGOLF_WHATS_IN_THE_BAG_URL,
   },
   {
     modelKey: 'mezz 1 max',
     displayName: 'LAB Golf Mezz 1 Max',
     usageRank: 6,
     playerCount: 10,
-    sourceUrl: 'https://www.datagolf.com/tools/whats-in-the-bag?club=putter',
+    sourceUrl: DATAGOLF_WHATS_IN_THE_BAG_URL,
   },
 ];


### PR DESCRIPTION
## Summary
- replace the stale DataGolf putter tool URL with the working "What's in the Bag" citation constant
- ensure every 2024 tour putter entry references the shared citation URL for consistent linking

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d9b0b30c8483259a738df4618a894e