### PR TITLE
Handle trivial search queries and add regression test

### DIFF
--- a/pages/api/__tests__/models.search.test.js
+++ b/pages/api/__tests__/models.search.test.js
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const searchModuleUrl = pathToFileURL(
+  path.join(__dirname, '..', 'models', 'search.js')
+).href;
+
+test('treats trivial queries as wildcard and returns top models', async () => {
+  const fakeRows = [
+    { model_key: 'scotty_cameron_newport', cnt: 42 },
+    { model_key: 'odyssey_white_hot', cnt: 31 },
+  ];
+
+  const { searchModels, default: handler } = await import(searchModuleUrl);
+
+  const req = { query: { q: 'putter' } };
+  const res = {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+
+  const fakeSql = (strings, ...values) => {
+    const text = strings.join(' ');
+    if (text.includes('SELECT')) {
+      assert.ok(!text.includes('LOWER(i.model_key) LIKE'));
+      return fakeRows;
+    }
+
+    assert.equal(text.trim(), '');
+    return '';
+  };
+
+  await handler({ ...req, testSql: fakeSql }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, {
+    ok: true,
+    q: 'putter',
+    models: fakeRows,
+  });
+
+  const rows = await searchModels(fakeSql, 'putter');
+
+  assert.deepEqual(rows, fakeRows);
+});

--- a/pages/api/models/search.js
+++ b/pages/api/models/search.js
@@ -1,24 +1,31 @@
 // pages/api/models/search.js
 export const runtime = 'nodejs';
-import { getSql } from '../../../lib/db';
+import { getSql } from '../../../lib/db.js';
+import { normalizeModelKey } from '../../../lib/normalize.js';
+
+export async function searchModels(sql, q = '') {
+  const normalized = normalizeModelKey(String(q || ''));
+  const hasMeaningfulQuery = normalized.length > 0;
+  const like = `%${normalized}%`;
+  return sql`
+    SELECT i.model_key, COUNT(*) AS cnt
+    FROM items i
+    JOIN item_prices ip ON ip.item_id = i.item_id
+    WHERE i.model_key IS NOT NULL
+      ${hasMeaningfulQuery ? sql`AND LOWER(i.model_key) LIKE ${like}` : sql``}
+      AND ip.total IS NOT NULL
+      AND ip.observed_at >= now() - interval '90 days'
+    GROUP BY i.model_key
+    ORDER BY cnt DESC
+    LIMIT 25
+  `;
+}
 
 export default async function handler(req, res) {
   try {
     const { q = '' } = req.query;
-    const sql = getSql();
-    const like = `%${q.toLowerCase()}%`;
-    const rows = await sql`
-      SELECT i.model_key, COUNT(*) AS cnt
-      FROM items i
-      JOIN item_prices ip ON ip.item_id = i.item_id
-      WHERE i.model_key IS NOT NULL
-        AND LOWER(i.model_key) LIKE ${like}
-        AND ip.total IS NOT NULL
-        AND ip.observed_at >= now() - interval '90 days'
-      GROUP BY i.model_key
-      ORDER BY cnt DESC
-      LIMIT 25
-    `;
+    const sql = req?.testSql || getSql();
+    const rows = await searchModels(sql, q);
     res.status(200).json({ ok: true, q, models: rows });
   } catch (e) {
     res.status(500).json({ ok: false, error: e.message });


### PR DESCRIPTION
## Summary
- treat trivial or brand-only model search terms as wildcards so the API still returns trending models
- reuse the new searchModels helper in the handler and allow dependency injection for tests
- cover the regression with a node:test suite exercising the search endpoint and helper directly

## Testing
- node --test pages/api/__tests__/*.js

------
https://chatgpt.com/codex/tasks/task_e_68d9b27388d88325a838037e8f4e4a08