### PR TITLE
Deduplicate model search counts

### DIFF
--- a/pages/api/__tests__/models.search.test.js
+++ b/pages/api/__tests__/models.search.test.js
@@ -33,6 +33,7 @@ test('treats trivial queries as wildcard and returns top models', async () => {
     const text = strings.join(' ');
     if (text.includes('SELECT')) {
       assert.ok(!text.includes('LOWER(i.model_key) LIKE'));
+      assert.ok(text.includes('COUNT(DISTINCT i.item_id) AS cnt'));
       return fakeRows;
     }
 

--- a/pages/api/models/search.js
+++ b/pages/api/models/search.js
@@ -8,7 +8,7 @@ export async function searchModels(sql, q = '') {
   const hasMeaningfulQuery = normalized.length > 0;
   const like = `%${normalized}%`;
   return sql`
-    SELECT i.model_key, COUNT(*) AS cnt
+    SELECT i.model_key, COUNT(DISTINCT i.item_id) AS cnt
     FROM items i
     JOIN item_prices ip ON ip.item_id = i.item_id
     WHERE i.model_key IS NOT NULL


### PR DESCRIPTION
## Summary
- count distinct item identifiers when aggregating model search results so each listing is only tallied once while keeping the existing filters in place
- adjust the model search unit test to reflect the distinct counting logic

## Testing
- node --test pages/api/__tests__/models.search.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9b8413aa08325b72eeebf56a65f67