### PR TITLE
Add Smart Price comparison table to homepage

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { headers } from "next/headers";
 import SmartPriceBadge from "@/components/SmartPriceBadge";
+import PriceComparisonTable from "@/components/PriceComparisonTable";
 import MarketSnapshot from "@/components/MarketSnapshot";
 import HeroSection from "@/components/HeroSection";
 import SectionWrapper from "@/components/SectionWrapper";
@@ -428,60 +429,20 @@ export default async function Home() {
           </div>
         )}
 
-        {tourModels.length > 0 && (
-          <div className="mx-auto mt-10 max-w-4xl text-left">
-            <div className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
-              <p className="text-sm uppercase tracking-wide text-emerald-200/80">Verified 2025 tour lineup</p>
-              <ul className="mt-4 space-y-4">
-                {tourModels.map((model) => {
-                  const avgPrice = Number(model?.snapshot?.price?.avg);
-                  const avgDisplay = Number.isFinite(avgPrice) ? formatCurrency(avgPrice) : "—";
-                  const sample = Number(model?.meta?.sampleSize) || 0;
-                  return (
-                    <li key={model.modelKey || model.displayName} className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                      <div>
-                        <p className="text-base font-semibold text-white">{model.displayName}</p>
-                        <p className="mt-1 text-xs text-slate-200/80">
-                          {sample > 0
-                            ? `Tracking ${sample.toLocaleString()} live listings · Typical ask ${avgDisplay}`
-                            : "Watching for fresh pricing data."}
-                        </p>
-                      </div>
-                      <div className="flex flex-col items-start gap-1 text-xs text-emerald-200 sm:items-end">
-                        <span>
-                          {model.usageRank ? `#${model.usageRank} in 2025 PGA Tour usage` : "Usage rank updating"}
-                          {model.playerCount ? ` · ${model.playerCount} players` : ""}
-                        </span>
-                        {model.sourceUrl ? (
-                          <a
-                            href={model.sourceUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-emerald-300 underline decoration-emerald-300/40 decoration-dotted underline-offset-4 transition hover:text-emerald-200"
-                          >
-                            Source citation
-                          </a>
-                        ) : null}
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          </div>
-        )}
       </HeroSection>
 
+      <PriceComparisonTable deals={deals} />
+
       <SectionWrapper variant="light">
-          <div className="max-w-3xl">
-            <h2 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
-              Today&apos;s best deals pulled straight from live listings
-            </h2>
-            <p className="mt-4 text-base text-slate-600">
-              These models currently have {deals.filter((d) => Number.isFinite(d.bestPrice)).length} Smart Price-verified listings with market-leading asks. Click through for filtered searches that stay synced with the live feed.
-            </p>
-          </div>
-          <div className="mt-12 grid gap-8 md:grid-cols-2 xl:grid-cols-3">
+        <div className="max-w-3xl">
+          <h2 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">
+            Today&apos;s best deals pulled straight from live listings
+          </h2>
+          <p className="mt-4 text-base text-slate-600">
+            These models currently have {deals.filter((d) => Number.isFinite(d.bestPrice)).length} Smart Price-verified listings with market-leading asks. Click through for filtered searches that stay synced with the live feed.
+          </p>
+        </div>
+        <div className="mt-12 grid gap-8 md:grid-cols-2 xl:grid-cols-3">
             {deals.length === 0 ? (
               <div className="col-span-full rounded-3xl border border-slate-200 bg-white p-8 text-center text-slate-600">
                 Smart Price is refreshing today&apos;s leaderboard—check back soon for verified deals.

--- a/components/PriceComparisonTable.jsx
+++ b/components/PriceComparisonTable.jsx
@@ -1,0 +1,166 @@
+import SmartPriceBadge from "@/components/SmartPriceBadge";
+
+function formatCurrency(value, currency = "USD") {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "—";
+  try {
+    return new Intl.NumberFormat("en-US", { style: "currency", currency }).format(value);
+  } catch {
+    return `$${value.toFixed(2)}`;
+  }
+}
+
+function formatPercent(value) {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "—";
+  const pct = value * 100;
+  const rounded = Math.abs(pct % 1) < 0.05 ? Math.round(pct) : Number(pct.toFixed(1));
+  return `${rounded}%`;
+}
+
+function formatCount(value) {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "—";
+  return value.toLocaleString();
+}
+
+export default function PriceComparisonTable({ deals = [] }) {
+  if (!Array.isArray(deals) || deals.length === 0) {
+    return null;
+  }
+
+  const rankedDeals = deals
+    .map((deal) => {
+      const bestPrice = Number.isFinite(deal?.bestPrice) ? Number(deal.bestPrice) : null;
+      const median = Number.isFinite(deal?.stats?.p50) ? Number(deal.stats.p50) : null;
+      const fallbackSavingsAmount = Number.isFinite(deal?.savings?.amount)
+        ? Number(deal.savings.amount)
+        : null;
+      const fallbackSavingsPercent = Number.isFinite(deal?.savings?.percent)
+        ? Number(deal.savings.percent)
+        : null;
+
+      const computedSavingsAmount =
+        Number.isFinite(median) && Number.isFinite(bestPrice) ? median - bestPrice : fallbackSavingsAmount;
+      const computedSavingsPercent =
+        Number.isFinite(median) && Number.isFinite(bestPrice) && median > 0
+          ? (median - bestPrice) / median
+          : fallbackSavingsPercent;
+
+      const listingCount = Number.isFinite(deal?.totalListings)
+        ? Number(deal.totalListings)
+        : Number.isFinite(deal?.statsMeta?.listingCount)
+          ? Number(deal.statsMeta.listingCount)
+          : null;
+
+      return {
+        key: deal?.query || deal?.label || null,
+        label: deal?.label || "Smart Price deal",
+        currency: deal?.currency || "USD",
+        bestPrice,
+        median,
+        savingsAmount: computedSavingsAmount,
+        savingsPercent: computedSavingsPercent,
+        listingCount,
+        stats: deal?.stats || null,
+        bestOffer: deal?.bestOffer || null,
+      };
+    })
+    .sort((a, b) => {
+      const pctA = Number.isFinite(a.savingsPercent) ? a.savingsPercent : -Infinity;
+      const pctB = Number.isFinite(b.savingsPercent) ? b.savingsPercent : -Infinity;
+      if (pctA !== pctB) return pctB - pctA;
+      const amtA = Number.isFinite(a.savingsAmount) ? a.savingsAmount : -Infinity;
+      const amtB = Number.isFinite(b.savingsAmount) ? b.savingsAmount : -Infinity;
+      if (amtA !== amtB) return amtB - amtA;
+      return (a.bestPrice || Infinity) - (b.bestPrice || Infinity);
+    });
+
+  return (
+    <div className="mx-auto max-w-6xl px-6 pb-16 pt-4">
+      <div className="overflow-hidden rounded-3xl border border-white/10 bg-slate-900/60 shadow-2xl shadow-emerald-500/10 backdrop-blur">
+        <div className="border-b border-white/5 bg-white/5 px-6 py-5">
+          <h2 className="text-xl font-semibold text-white sm:text-2xl">Smart Price comparison snapshot</h2>
+          <p className="mt-1 text-sm text-slate-300">
+            Ranked by verified savings so you can jump straight to the biggest market gaps right now.
+          </p>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-white/5 text-sm text-slate-200">
+            <thead className="bg-white/5 text-xs uppercase tracking-wide text-slate-400">
+              <tr>
+                <th scope="col" className="py-3 pl-6 pr-3 text-left font-medium text-slate-300">
+                  Model
+                </th>
+                <th scope="col" className="px-3 py-3 text-left font-medium text-slate-300">
+                  Smart Price ask
+                </th>
+                <th scope="col" className="px-3 py-3 text-left font-medium text-slate-300">
+                  Median ask
+                </th>
+                <th scope="col" className="px-3 py-3 text-left font-medium text-slate-300">
+                  Savings
+                </th>
+                <th scope="col" className="py-3 pl-3 pr-6 text-right font-medium text-slate-300">
+                  Listings tracked
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              {rankedDeals.map((deal, index) => {
+                const amountText = Number.isFinite(deal.savingsAmount)
+                  ? formatCurrency(deal.savingsAmount, deal.currency)
+                  : null;
+                const percentText = Number.isFinite(deal.savingsPercent)
+                  ? formatPercent(deal.savingsPercent)
+                  : null;
+                const savingsLabel = amountText && percentText
+                  ? `${amountText} (${percentText})`
+                  : amountText || percentText || "—";
+
+                return (
+                  <tr key={`${deal.key || "deal"}-${index}`} className="bg-slate-900/40 transition hover:bg-slate-900/70">
+                    <th scope="row" className="whitespace-nowrap py-4 pl-6 pr-3 text-left">
+                      <div className="flex items-start gap-3">
+                        <span className="text-xs font-semibold text-emerald-300/80">#{index + 1}</span>
+                        <div>
+                          <p className="font-semibold text-white">{deal.label}</p>
+                          <p className="mt-1 text-xs text-slate-400">
+                            {Number.isFinite(deal.listingCount)
+                              ? `${formatCount(deal.listingCount)} live listings tracked`
+                              : "Live savings snapshot"}
+                          </p>
+                        </div>
+                      </div>
+                    </th>
+                    <td className="px-3 py-4">
+                      <div className="flex flex-wrap items-center gap-3">
+                        <span className="text-base font-semibold text-emerald-300">
+                          {formatCurrency(deal.bestPrice, deal.currency)}
+                        </span>
+                        <SmartPriceBadge
+                          price={deal.bestPrice}
+                          baseStats={deal.stats}
+                          title={deal.bestOffer?.title}
+                          specs={deal.bestOffer?.specs}
+                          brand={deal.bestOffer?.brand}
+                          className="shrink-0"
+                        />
+                      </div>
+                    </td>
+                    <td className="px-3 py-4 text-base font-medium text-slate-100">
+                      {formatCurrency(deal.median, deal.currency)}
+                    </td>
+                    <td className="px-3 py-4 text-base font-medium text-emerald-200">
+                      {savingsLabel}
+                    </td>
+                    <td className="py-4 pl-3 pr-6 text-right text-base font-medium text-slate-100">
+                      {formatCount(deal.listingCount)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a reusable PriceComparisonTable component that ranks deals by Smart Price savings
- remove the tour lineup list from the hero and surface the new comparison table beneath the hero snapshot

## Testing
- npm run dev *(fails: API routes require DATABASE_URL in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ba7b97c4832585eb7929ea22e6ba