### PR TITLE
Add cached trending sparkline visualization

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -5,6 +5,7 @@ import MarketSnapshot from "@/components/MarketSnapshot";
 import HeroSection from "@/components/HeroSection";
 import SectionWrapper from "@/components/SectionWrapper";
 import HighlightCard from "@/components/HighlightCard";
+import TrendingSparkline from "@/components/TrendingSparkline";
 
 const DEFAULT_SNAPSHOT_QUERY = "golf putter";
 
@@ -593,6 +594,7 @@ export default async function Home() {
                       ? `${item.count.toLocaleString()} recent listings tracked`
                       : "Pulling market counts…"}
                   </p>
+                  <TrendingSparkline modelKey={item.modelKey} className="text-emerald-500" />
                   <div className="mt-6">
                     <Link
                       href={href}

--- a/components/TrendingSparkline.jsx
+++ b/components/TrendingSparkline.jsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import PriceSparkline from "./PriceSparkline";
+
+const cache = new Map();
+
+function mapSeriesPayload(payload) {
+  if (!payload || !Array.isArray(payload.series)) return [];
+  return payload.series
+    .map((row) => {
+      const rawTs = row.day ?? row.ts ?? row.date ?? row.x;
+      const rawTotal = row.median ?? row.total ?? row.price ?? row.y ?? row.value;
+
+      let ts = Number.isFinite(rawTs) ? Number(rawTs) : NaN;
+      if (!Number.isFinite(ts) && rawTs != null) {
+        const parsed = rawTs instanceof Date ? rawTs.getTime() : Date.parse(rawTs);
+        ts = Number.isFinite(parsed) ? parsed : NaN;
+      }
+
+      const total = Number(rawTotal);
+
+      if (!Number.isFinite(ts) || !Number.isFinite(total)) return null;
+      return { ts, total };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.ts - b.ts);
+}
+
+function fetchSeries(modelKey) {
+  if (!modelKey) return Promise.resolve([]);
+
+  const cached = cache.get(modelKey);
+  if (cached) {
+    if (cached.status === "fulfilled") return Promise.resolve(cached.data);
+    if (cached.status === "rejected") return Promise.reject(cached.error);
+    return cached.promise;
+  }
+
+  const promise = fetch(`/api/analytics/series?model=${encodeURIComponent(modelKey)}`)
+    .then(async (res) => {
+      if (!res.ok) throw new Error("Failed to load market trend");
+      const json = await res.json();
+      if (!json?.ok) throw new Error(json?.error || "Failed to load market trend");
+      return mapSeriesPayload(json);
+    })
+    .then((data) => {
+      cache.set(modelKey, { status: "fulfilled", data });
+      return data;
+    })
+    .catch((error) => {
+      cache.set(modelKey, { status: "rejected", error });
+      throw error;
+    });
+
+  cache.set(modelKey, { status: "pending", promise });
+  return promise;
+}
+
+export default function TrendingSparkline({ modelKey, className = "" }) {
+  const [state, setState] = useState({ loading: !!modelKey, error: null, data: [] });
+  const rootClass = ["mt-4", className].filter(Boolean).join(" ");
+
+  useEffect(() => {
+    let active = true;
+    if (!modelKey) {
+      setState({ loading: false, error: null, data: [] });
+      return () => {
+        active = false;
+      };
+    }
+
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+
+    fetchSeries(modelKey)
+      .then((data) => {
+        if (!active) return;
+        setState({ loading: false, error: null, data });
+      })
+      .catch((error) => {
+        if (!active) return;
+        setState({ loading: false, error: error.message || "Unable to load trend", data: [] });
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [modelKey]);
+
+  if (state.loading) {
+    return <div className={`${rootClass} h-16 w-full animate-pulse rounded-xl bg-slate-100`} aria-hidden />;
+  }
+
+  if (state.error) {
+    return <p className={`${rootClass} text-xs text-rose-500`}>Market trend unavailable right now.</p>;
+  }
+
+  if (!state.data.length) {
+    return <div className={`${rootClass} text-xs text-slate-400`}>Trend warming up…</div>;
+  }
+
+  return (
+    <div className={rootClass}>
+      <PriceSparkline data={state.data} height={64} showAverage={false} showMedian className="h-16" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a client TrendingSparkline component that requests the analytics series for a model and caches results per key
- map the API response into the structure expected by PriceSparkline with loading and error fallbacks
- render the sparkline with the median guide beneath the listing count inside each trending card

## Testing
- npm run lint *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68d9ba7ce2588325a41a96bbfe1e4b86