### PR TITLE
Ensure hero snapshot query fallback

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -421,6 +421,7 @@ export default async function Home() {
 
         {heroSnapshot && (
           <div className="mt-16">
+            {/* Ensure the snapshot query falls back to the default when none is resolved */}
             <MarketSnapshot
               snapshot={heroSnapshot}
               meta={snapshotMeta}


### PR DESCRIPTION
## Summary
- document that the hero MarketSnapshot uses the resolved search query with the default fallback
- keep the query prop pointing to `snapshotQuery || DEFAULT_SNAPSHOT_QUERY` to preserve the original search context

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9bf269f788325906be26fcb5974f8