### PR TITLE
Fix hero MarketSnapshot query binding

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -421,12 +421,7 @@ export default async function Home() {
 
         {heroSnapshot && (
           <div className="mt-16">
-            {/* Ensure the snapshot query falls back to the default when none is resolved */}
-            <MarketSnapshot
-              snapshot={heroSnapshot}
-              meta={snapshotMeta}
-              query={snapshotQuery || DEFAULT_SNAPSHOT_QUERY}
-            />
+            <MarketSnapshot snapshot={heroSnapshot} meta={snapshotMeta} query={snapshotQuery} />
           </div>
         )}
       </HeroSection>


### PR DESCRIPTION
## Summary
- update the hero MarketSnapshot instance to receive the resolved snapshotQuery value so its header mirrors the CTA link text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9c0904e64832589716cbf86e6b8a0