### PR TITLE
Allow PriceSparkline color to be customized

### DIFF
--- a/app/putters/page.js
+++ b/app/putters/page.js
@@ -1226,7 +1226,13 @@ export default function PuttersPage() {
 
                             {isOpen && Array.isArray(series) && series.length > 1 && (
                               <div className="mt-4">
-                                <PriceSparkline data={series} height={70} showAverage showMedian className="h-[70px]" />
+                                <PriceSparkline
+                                  data={series}
+                                  height={70}
+                                  showAverage
+                                  showMedian
+                                  className="h-[70px] text-sky-600"
+                                />
                               </div>
                             )}
 

--- a/app/putters/page2.js
+++ b/app/putters/page2.js
@@ -1062,7 +1062,13 @@ export default function PuttersPage() {
                     {/* Sparkline */}
                     {isOpen && Array.isArray(series) && series.length > 1 && (
                       <div className="mt-3">
-                        <PriceSparkline data={series} height={70} showAverage showMedian className="h-[70px]" />
+                        <PriceSparkline
+                          data={series}
+                          height={70}
+                          showAverage
+                          showMedian
+                          className="h-[70px] text-sky-600"
+                        />
                       </div>
                     )}
 

--- a/app/putters/temp.js
+++ b/app/putters/temp.js
@@ -1033,7 +1033,13 @@ export default function PuttersPage() {
                     {/* Sparkline */}
                     {isOpen && Array.isArray(series) && series.length > 1 && (
                       <div className="mt-3">
-                        <PriceSparkline data={series} height={70} showAverage showMedian className="h-[70px]" />
+                        <PriceSparkline
+                          data={series}
+                          height={70}
+                          showAverage
+                          showMedian
+                          className="h-[70px] text-sky-600"
+                        />
                       </div>
                     )}
 

--- a/components/PriceSparkline.js
+++ b/components/PriceSparkline.js
@@ -115,8 +115,10 @@ export default function PriceSparkline({
 
   // Use currentColor for themeable stroke/fill; parent sets color.
   // Example parent wrappers: "text-sky-600" or "text-emerald-600"
+  const wrapperClassName = ['w-full', className].filter(Boolean).join(' ');
+
   return (
-    <div className={`w-full text-sky-600 ${className}`}>
+    <div className={wrapperClassName}>
       <ResponsiveContainer width="100%" height={height}>
         <AreaChart
           data={series.points}


### PR DESCRIPTION
## Summary
- remove the hard-coded text color from PriceSparkline so consumers can control the hue
- set text-sky-600 on putter results sparkline instances to preserve their existing styling

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d9c21e6ddc8325ab388a6111e97a89