### PR TITLE
Restore hero snapshot query fallback

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -421,7 +421,11 @@ export default async function Home() {
 
         {heroSnapshot && (
           <div className="mt-16">
-            <MarketSnapshot snapshot={heroSnapshot} meta={snapshotMeta} query={snapshotQuery} />
+            <MarketSnapshot
+              snapshot={heroSnapshot}
+              meta={snapshotMeta}
+              query={snapshotQuery || DEFAULT_SNAPSHOT_QUERY}
+            />
           </div>
         )}
       </HeroSection>


### PR DESCRIPTION
## Summary
- ensure the hero MarketSnapshot uses the search query when available
- fall back to the default snapshot query when no query is present to match previous behavior

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9c333f1888325853829d5a5f5a9a1