### PR TITLE
Ensure live listing fetches bypass caching

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -246,7 +246,7 @@ export default async function Home() {
   const baseUrl = await resolveBaseUrl();
 
   const topDealsRes = await fetchJson(`${baseUrl}/api/top-deals`, {
-    next: { revalidate: 300 },
+    cache: "no-store",
   });
 
   const dealsRaw = Array.isArray(topDealsRes?.deals) ? topDealsRes.deals : [];
@@ -283,7 +283,7 @@ export default async function Home() {
   });
 
   const trendingRes = await fetchJson(`${baseUrl}/api/models/search?q=putter`, {
-    next: { revalidate: 3600 },
+    cache: "no-store",
   });
 
   const trending = Array.isArray(trendingRes?.models)
@@ -302,7 +302,7 @@ export default async function Home() {
   const snapshotResponse = await fetchJson(
     `${baseUrl}/api/putters?q=${encodeURIComponent(DEFAULT_SNAPSHOT_QUERY)}`,
     {
-      next: { revalidate: 300 },
+      cache: "no-store",
     }
   );
 


### PR DESCRIPTION
## Summary
- update the home page data fetches for top deals, trending models, and the market snapshot to use `cache: "no-store"` so listings always reflect current data
- confirmed the deployment configuration (e.g., `vercel.json`) does not define ISR settings that would override the no-store behavior

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da0bd79a4883259ef1f05ad21c59c4