### PR TITLE
Align marketing copy with live listing percentiles

### DIFF
--- a/app/methodology/methodology-page.js
+++ b/app/methodology/methodology-page.js
@@ -16,31 +16,34 @@ export default function MethodologyPage() {
     <main className="mx-auto max-w-3xl px-4 py-10">
       <h1 className="text-3xl font-semibold tracking-tight">How We Calculate Fair Prices</h1>
       <p className="mt-3 text-slate-600">
-        PutterIQ estimates a fair market price for each model (and condition band) using robust statistics from recent
-        comparable sales. We highlight listings that are below, near, or above that expectation with a color-coded badge
-        and an optional deal score.
+        PutterIQ estimates a live market baseline for each model (and condition band) using percentile distributions built
+        from recent eBay listing history. We highlight listings that are below, near, or above that live baseline with a
+        color-coded badge and an optional deal score.
       </p>
 
       <section className="mt-8 space-y-5">
         <Row label="Data window">
-          We use recent sold listings (typically 60–90 days). Old or extreme outliers are down-weighted or discarded.
+          We analyze a rolling 60–90 day window of live listing history (including active and recently ended inventory) and
+          refresh throughout the day. Stale snapshots are removed quickly so baselines reflect the current market.
         </Row>
 
         <Row label="Condition bands">
-          Prices are computed separately for: <strong>New</strong>, <strong>Like‑New</strong>, <strong>Good</strong>, <strong>Fair</strong>.
-          If insufficient data exists for a band, we fall back to the model median with a lower confidence.
+          Baselines are computed separately for: <strong>New</strong>, <strong>Like‑New</strong>, <strong>Good</strong>, <strong>Fair</strong>.
+          When a band lacks data, we fall back to the overall model median and lower the confidence signal.
         </Row>
 
         <Row label="Cleaning & outliers">
-          We remove invalid prices and trim the tails (e.g., top/bottom 5%) to reduce the impact of outliers and rare bundles.
+          We remove invalid asks, duplicate listings, and trim the tails (e.g., top/bottom 5%) to reduce the impact of
+          outliers and rare bundles.
         </Row>
 
         <Row label="Expected price">
-          The primary estimator is the <strong>median</strong> (p50) of comparable sold prices after cleaning and trimming.
+          The primary estimator is the <strong>median</strong> (p50) of live listing totals after cleaning and trimming.
         </Row>
 
         <Row label="Dispersion & confidence">
-          We compute dispersion (e.g., IQR/median) and sample size <code>n</code>. Confidence increases with more sales and tighter dispersion.
+          We compute dispersion (e.g., IQR/median) and sample size <code>n</code>. Confidence increases with more qualifying listings
+          and tighter spreads in the live ask distribution.
         </Row>
 
         <Row label="Badge tiers">

--- a/app/page.js
+++ b/app/page.js
@@ -261,7 +261,7 @@ export default async function Home() {
       item?.blurb ||
       (Number.isFinite(roundedPct)
         ? `Smart Price spotted about ${roundedPct}% below the typical ask on this model today.`
-        : "Smart Price benchmarks live listings against historical comps to surface real savings.");
+        : "Smart Price benchmarks every live listing against fresh percentile baselines to surface real savings.");
 
     return {
       label: item?.label || item?.modelKey || "Live Smart Price deal",
@@ -355,7 +355,7 @@ export default async function Home() {
           <p className="mt-6 text-lg leading-8 text-slate-200">
             {smartExample && exampleMedian && Number.isFinite(exampleGap) && exampleGap > 0 ? (
               <>
-                Smart Price watches every live putter listing and compares it to recent sale percentiles. Right now it has {smartExample.label}
+                Smart Price watches every live putter listing and compares it to recent live listing percentiles. Right now it has {smartExample.label}
                 {" "}
                 sitting at {formatCurrency(smartExample.bestPrice, smartExample.currency)}, about
                 {" "}
@@ -366,7 +366,7 @@ export default async function Home() {
                 , confirmed by the Smart Price badge.
               </>
             ) : (
-              <>Smart Price watches every live putter listing and compares it to recent sale percentiles so verified savings surface automatically.</>
+              <>Smart Price watches every live putter listing and compares it to recent live listing percentiles so verified savings surface automatically.</>
             )}
           </p>
           <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
@@ -399,8 +399,8 @@ export default async function Home() {
                   </h2>
                   <p className="mt-2 text-sm text-slate-200">
                     {exampleSavings !== null
-                      ? `We compare every listing against recent sale percentiles. This one sits about ${Math.round(exampleSavings)}% below the typical asking price, so Smart Price flags it automatically.`
-                      : "We compare every listing against recent sale percentiles. Smart Price highlights the standouts as soon as fresh comps confirm the savings."}
+                      ? `We compare every listing against recent live listing percentiles. This one sits about ${Math.round(exampleSavings)}% below the typical asking price, so Smart Price flags it automatically.`
+                      : "We compare every listing against recent live listing percentiles. Smart Price highlights the standouts as soon as fresh baseline data confirms the savings."}
                   </p>
                 </div>
                 <SmartPriceBadge
@@ -414,7 +414,7 @@ export default async function Home() {
             </div>
           ) : (
             <div className="mx-auto mt-8 max-w-3xl rounded-2xl border border-white/10 bg-white/5 p-6 text-center text-sm text-slate-200 backdrop-blur">
-              Smart Price is crunching today&apos;s listings. Fresh deal examples appear here as soon as we validate the savings against recent comps.
+              Smart Price is crunching today&apos;s listings. Fresh deal examples appear here as soon as we validate the savings against updated live listing percentiles.
             </div>
           )}
         </div>
@@ -497,7 +497,7 @@ export default async function Home() {
                       </div>
                       {Number.isFinite(median) && (
                         <p className="text-xs text-slate-600">
-                          Median over recent comps: {formatCurrency(median, deal.currency)}
+                          Median from live percentile baseline: {formatCurrency(median, deal.currency)}
                           {Number.isFinite(diff) && diff > 0 ? (
                             <>
                               {" "}· Save about {formatCurrency(diff, deal.currency)}
@@ -535,7 +535,7 @@ export default async function Home() {
           <div className="max-w-3xl">
             <h2 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl">Trending models on eBay</h2>
             <p className="mt-4 text-base text-slate-600">
-              Our database looks across the last 90 days of completed listings to highlight where buyer attention is spiking. Jump straight into a focused search for each hot model.
+              Our database looks across the last 90 days of live listing history to highlight where buyer attention is spiking. Jump straight into a focused search for each hot model.
             </p>
           </div>
           <div className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">

--- a/app/putters/page.js
+++ b/app/putters/page.js
@@ -92,8 +92,8 @@ function makeSmartBadge({ listingPrice, stats, windowDays = 60 }) {
   const nText = n ? `${n}` : "—";
   const condLabel = stats?.condition ? ` (${String(stats.condition).replace(/_/g," ").toLowerCase()})` : "";
   const tooltip = tier === "insufficient"
-    ? "Not enough comparable sales to estimate a fair market price confidently."
-    : `Based on ${nText} comparable sales${condLabel} in ~${windowDays} days. This listing is ${vsText} expected (median). Confidence: ${confidence}.`;
+    ? "Not enough live listing history to estimate a fair market baseline confidently."
+    : `Based on ${nText} live listings${condLabel} observed in ~${windowDays} days. This listing is ${vsText} the live median. Confidence: ${confidence}.`;
 
   return {
     tier,
@@ -669,7 +669,7 @@ export default function PuttersPage() {
             Type a model (e.g., <em>“scotty cameron newport”</em>) or pick a brand to benchmark pricing in real-time.
           </p>
           <p className="text-sm text-slate-300">
-            Badges based on recent comps.{" "}
+            Badges based on live listing percentiles.{" "}
             <a className="font-semibold text-emerald-300 underline hover:text-emerald-200" href="/methodology">
               See methodology
             </a>

--- a/app/putters/page2.js
+++ b/app/putters/page2.js
@@ -90,8 +90,8 @@ function makeSmartBadge({ listingPrice, stats, windowDays = 60 }) {
   const nText = n ? `${n}` : "—";
   const condLabel = stats?.condition ? ` (${String(stats.condition).replace(/_/g," ").toLowerCase()})` : "";
   const tooltip = tier === "insufficient"
-    ? "Not enough comparable sales to estimate a fair market price confidently."
-    : `Based on ${nText} comparable sales${condLabel} in ~${windowDays} days. This listing is ${vsText} expected (median). Confidence: ${confidence}.`;
+    ? "Not enough live listing history to estimate a fair market baseline confidently."
+    : `Based on ${nText} live listings${condLabel} observed in ~${windowDays} days. This listing is ${vsText} the live median. Confidence: ${confidence}.`;
 
   return {
     tier,
@@ -589,7 +589,7 @@ export default function PuttersPage() {
             Type a model (e.g., <em>“scotty cameron newport”</em>) or pick a brand.
           </p>
           <p className="mt-1 text-xs text-gray-500">
-            Badges based on recent comps. <a className="text-blue-600 underline" href="/methodology">See methodology</a>.
+            Badges based on live listing percentiles. <a className="text-blue-600 underline" href="/methodology">See methodology</a>.
           </p>
         </div>
         {q.trim() && (

--- a/app/putters/temp.js
+++ b/app/putters/temp.js
@@ -86,8 +86,8 @@ function makeSmartBadge({ listingPrice, stats, windowDays = 60 }) {
                : "near";
   const nText = n ? `${n}` : "—";
   const tooltip = tier === "insufficient"
-    ? "Not enough comparable sales to estimate a fair market price confidently."
-    : `Based on ${nText} comparable sales in ~${windowDays} days. This listing is ${vsText} expected (median). Confidence: ${confidence}.`;
+    ? "Not enough live listing history to estimate a fair market baseline confidently."
+    : `Based on ${nText} live listings in ~${windowDays} days. This listing is ${vsText} the live median. Confidence: ${confidence}.`;
 
   return {
     tier,

--- a/components/PriceComparisonTable.jsx
+++ b/components/PriceComparisonTable.jsx
@@ -57,7 +57,7 @@ export default function PriceComparisonTable({ deals = [] }) {
           <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">Smart Price leaderboard</h2>
           <p className="mt-3 text-base text-slate-600">
             Compare today&apos;s top ranked putter deals at a glance. Smart Price monitors every live listing and
-            highlights the models with verified savings confirmed by recent comps.
+            highlights the models with verified savings confirmed by live percentile baselines.
           </p>
         </div>
 
@@ -73,7 +73,7 @@ export default function PriceComparisonTable({ deals = [] }) {
                     Best live ask
                   </th>
                   <th scope="col" className="px-6 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                    Recent median
+                    Median live ask
                   </th>
                   <th scope="col" className="px-6 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
                     Savings
@@ -169,7 +169,7 @@ export default function PriceComparisonTable({ deals = [] }) {
                       </dd>
                     </div>
                     <div>
-                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Recent median</dt>
+                      <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">Median live ask</dt>
                       <dd className="mt-1 text-slate-700">
                         {Number.isFinite(median) ? formatCurrency(median, row.currency) : "—"}
                       </dd>

--- a/components/SmartPriceBadge.jsx
+++ b/components/SmartPriceBadge.jsx
@@ -91,7 +91,7 @@ function chooseBadge({ price, baseStats, variantStats, looksPremium }) {
       tone: "indigo",
       label: "Special variant",
       tooltip:
-        "Tour/Limited signals detected but variant comps are thin. Comparing to base would be misleading.",
+        "Tour/Limited signals detected but variant baselines are thin. Comparing to the broader model would be misleading.",
     };
   }
 


### PR DESCRIPTION
## Summary
- refresh the homepage hero explanation and trending copy to describe Smart Price using live listing percentile baselines
- update deal blurbing, leaderboard messaging, and badge tooltips across listing pages to reference live listing history instead of completed sales
- rewrite the methodology page to outline the new live listing data window, cleaning, and confidence calculations

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68da0d35c99c83259ea8c196814af0a3