### PR TITLE
Persist canonical brands and harden search queries

### DIFF
--- a/lib/sanitizeModelKey.js
+++ b/lib/sanitizeModelKey.js
@@ -31,31 +31,62 @@ Object.entries(BRAND_SYNONYMS).forEach(([brand, aliases]) => {
   });
 });
 
-/**
- * Examples:
- * sanitizeModelKey("Titleist|Scotty Cameron|Super Select|Cameron");
- * // => { label: "Super Select", query: "Scotty Cameron Super Select" }
- *
- * sanitizeModelKey("Odyssey|White Hot OG|2-Ball|35");
- * // => { label: "White Hot OG 2-Ball 35", query: "Odyssey White Hot OG 2-Ball" }
- *
- * sanitizeModelKey("mint TaylorMade my spider tour x x3 34.5 putter");
- * // => { label: "mint TaylorMade my spider tour x x3 34.5 putter", query: "TaylorMade my spider tour x x3 putter" }
- */
-export function sanitizeModelKey(rawKey = "") {
-  if (!rawKey) {
-    return {
-      label: "Model updating",
-      query: "",
-    };
-  }
+const ACCESSORY_EXACT_TOKENS = new Set(
+  [
+    "adapter",
+    "adapters",
+    "counterweight",
+    "counterweights",
+    "fit",
+    "fits",
+    "fitting",
+    "fittings",
+    "grip",
+    "grips",
+    "headcover",
+    "headcovers",
+    "insert",
+    "inserts",
+    "kit",
+    "kits",
+    "pack",
+    "package",
+    "set",
+    "sleeve",
+    "sleeves",
+    "tool",
+    "tools",
+    "weight",
+    "weights",
+    "wrench",
+    "wrenches",
+  ].map((token) => token.toLowerCase())
+);
 
-  const segments = String(rawKey)
+const ACCESSORY_TOKEN_PATTERNS = [
+  /^\d+(?:\/\d+)?(?:pc|pcs|pack|set)s?$/i,
+  /^\d+(?:pcs?)$/i,
+  /^\d+(?:g|gram|grams)$/i,
+  /^\d+(?:mm|cm)$/i,
+];
+
+function isAccessoryToken(token = "") {
+  if (!token) return false;
+  const normalized = token.toLowerCase();
+  if (ACCESSORY_EXACT_TOKENS.has(normalized)) return true;
+  const stripped = normalized.replace(/[^a-z0-9]+/g, "");
+  if (ACCESSORY_EXACT_TOKENS.has(stripped)) return true;
+  return ACCESSORY_TOKEN_PATTERNS.some((pattern) => pattern.test(token));
+}
+
+function splitSegments(rawKey = "") {
+  return String(rawKey)
     .split(/::|\|/g)
     .map((segment) => segment.trim())
     .filter(Boolean);
+}
 
-  const working = segments.join(" ");
+function detectBrandFromSegments(segments = []) {
   const brandMatches = new Map();
   const recordMatch = (brand, index, source) => {
     if (!brand) return;
@@ -87,30 +118,79 @@ export function sanitizeModelKey(rawKey = "") {
     }
   });
 
-  let detectedBrand = null;
-  if (brandMatches.size) {
-    let candidates = Array.from(brandMatches.values());
-    const normalizedCandidates = new Set(candidates.map((c) => c.brand.toLowerCase()));
-    const filtered = candidates.filter((candidate) => {
-      const canonicalBrand = BRAND_ALIAS_LOOKUP.get(candidate.brand.toLowerCase());
-      if (!canonicalBrand) return true;
-      return !normalizedCandidates.has(canonicalBrand.toLowerCase());
-    });
-    if (filtered.length) {
-      candidates = filtered;
-    }
-    const winner = candidates.reduce((best, candidate) => {
-      if (!best) return candidate;
-      if (candidate.priority !== best.priority) {
-        return candidate.priority > best.priority ? candidate : best;
-      }
-      if (candidate.brand.length !== best.brand.length) {
-        return candidate.brand.length > best.brand.length ? candidate : best;
-      }
-      return candidate.index < best.index ? candidate : best;
-    }, null);
-    detectedBrand = winner ? winner.brand : null;
+  if (!brandMatches.size) {
+    return null;
   }
+
+  let candidates = Array.from(brandMatches.values());
+  const normalizedCandidates = new Set(candidates.map((c) => c.brand.toLowerCase()));
+  const filtered = candidates.filter((candidate) => {
+    const canonicalBrand = BRAND_ALIAS_LOOKUP.get(candidate.brand.toLowerCase());
+    if (!canonicalBrand) return true;
+    return !normalizedCandidates.has(canonicalBrand.toLowerCase());
+  });
+  if (filtered.length) {
+    candidates = filtered;
+  }
+  const winner = candidates.reduce((best, candidate) => {
+    if (!best) return candidate;
+    if (candidate.priority !== best.priority) {
+      return candidate.priority > best.priority ? candidate : best;
+    }
+    if (candidate.brand.length !== best.brand.length) {
+      return candidate.brand.length > best.brand.length ? candidate : best;
+    }
+    return candidate.index < best.index ? candidate : best;
+  }, null);
+  return winner ? winner.brand : null;
+}
+
+export function detectCanonicalBrand(rawKey = "") {
+  const segments = Array.isArray(rawKey) ? rawKey : splitSegments(rawKey);
+  let detected = detectBrandFromSegments(segments);
+  if (!detected) {
+    const fallbackText = Array.isArray(rawKey)
+      ? rawKey.filter(Boolean).join(" ")
+      : String(rawKey || "");
+    if (fallbackText) {
+      detected = detectBrandFromSegments([fallbackText]);
+    }
+  }
+  return detected || null;
+}
+
+export function stripAccessoryTokens(text = "") {
+  if (!text) return "";
+  const tokens = String(text)
+    .split(/\s+/)
+    .filter(Boolean)
+    .filter((token) => !isAccessoryToken(token));
+  return tokens.join(" ");
+}
+
+/**
+ * Examples:
+ * sanitizeModelKey("Titleist|Scotty Cameron|Super Select|Cameron");
+ * // => { label: "Super Select", query: "Scotty Cameron Super Select" }
+ *
+ * sanitizeModelKey("Odyssey|White Hot OG|2-Ball|35");
+ * // => { label: "White Hot OG 2-Ball 35", query: "Odyssey White Hot OG 2-Ball" }
+ *
+ * sanitizeModelKey("mint TaylorMade my spider tour x x3 34.5 putter");
+ * // => { label: "mint TaylorMade my spider tour x x3 34.5 putter", query: "TaylorMade my spider tour x x3 putter" }
+ */
+export function sanitizeModelKey(rawKey = "", options = {}) {
+  const { storedBrand = null } = options || {};
+  if (!rawKey) {
+    return {
+      label: "Model updating",
+      query: "",
+    };
+  }
+
+  const segments = splitSegments(rawKey);
+  const working = segments.join(" ");
+  const detectedBrand = detectBrandFromSegments(segments);
 
   const aliasList = detectedBrand ? BRAND_ALIASES.get(detectedBrand) || [detectedBrand] : [];
   const aliasSet = new Set(aliasList.map((alias) => alias.toLowerCase()));
@@ -139,8 +219,10 @@ export function sanitizeModelKey(rawKey = "") {
   }
 
   const fallbackText = working || String(rawKey).trim();
-  const cleanedLabel = label.trim();
-  const humanLabel = cleanedLabel || fallbackText;
+  const accessoryFreeLabel = stripAccessoryTokens(label).trim();
+  const cleanedLabel = accessoryFreeLabel;
+  const fallbackLabel = stripAccessoryTokens(fallbackText).trim() || fallbackText;
+  const humanLabel = cleanedLabel || fallbackLabel;
 
   const lengthTokenPattern = /^\d+(?:\.\d+)?(?:(?:in)|["”])?$/i;
   const descriptorTokens = new Set([
@@ -165,28 +247,35 @@ export function sanitizeModelKey(rawKey = "") {
         .filter((token) => {
           if (!token || lengthTokenPattern.test(token)) return false;
           const normalized = token.toLowerCase();
-          return !descriptorTokens.has(normalized);
+          if (descriptorTokens.has(normalized)) return false;
+          return !isAccessoryToken(token);
         })
     : [];
   const searchText = searchTokens.join(" ").trim();
 
+  const brandForQuery =
+    (typeof storedBrand === "string" && storedBrand.trim()) || detectedBrand || null;
+  const queryAliasList = brandForQuery ? BRAND_ALIASES.get(brandForQuery) || [brandForQuery] : [];
+
   let query = "";
-  if (searchText && detectedBrand) {
+  if (searchText && brandForQuery) {
     const lowerSearch = searchText.toLowerCase();
-    const searchStartsWithBrand = aliasList.some((alias) =>
+    const searchStartsWithBrand = queryAliasList.some((alias) =>
       lowerSearch.startsWith(alias.toLowerCase())
     );
-    query = searchStartsWithBrand ? searchText : `${detectedBrand} ${searchText}`.trim();
+    query = searchStartsWithBrand ? searchText : `${brandForQuery} ${searchText}`.trim();
   } else if (searchText) {
     query = searchText;
   }
 
   if (!query) {
-    query = fallbackText;
+    const fallbackQuery = stripAccessoryTokens(fallbackText).trim();
+    query = fallbackQuery || fallbackText;
   }
 
   return {
     label: humanLabel,
     query,
+    brand: brandForQuery,
   };
 }


### PR DESCRIPTION
## Summary
- persist a canonical brand on collected items using the shared detection helper
- extend sanitizeModelKey to drop accessory-only tokens and honour stored brands when building queries
- update the top deals API to lean on brand-backed queries and provide a putter-safe fallback CTA

## Testing
- npm run lint *(fails: Missing script "lint")*
- node -e "import('./lib/sanitizeModelKey.js').then((m) => { const r = m.sanitizeModelKey('TaylorMade Spider Tour Weight Kit 2pcs'); console.log(r); });"
- curl -s "http://localhost:3000/api/putters?q=spider%20tour" | head

------
https://chatgpt.com/codex/tasks/task_e_68dacd0b8dd88325be544afe69a740f2