### PR TITLE
Add refresh mode to cron to revisit stale eBay listings

### DIFF
--- a/pages/api/cron/collect-prices.js
+++ b/pages/api/cron/collect-prices.js
@@ -32,6 +32,167 @@ function pickShipping(item) {
   const v = so?.shippingCost?.value ?? so?.shippingCost?.convertedFromValue;
   return readNumber(v);
 }
+
+function extractListingSnapshot(raw) {
+  const itemId = raw?.itemId || raw?.item_id;
+  if (!itemId) return null;
+
+  const title = raw?.title || null;
+  const currency = raw?.price?.currency || raw?.price?.convertedFromCurrency || 'USD';
+  const price =
+    readNumber(raw?.price?.value) ?? readNumber(raw?.price?.convertedFromValue);
+  const shipping = pickShipping(raw);
+  const total = price != null && shipping != null ? price + shipping : price ?? null;
+  const condition = raw?.condition || raw?.conditionDisplayName || null;
+  const url = raw?.itemWebUrl || raw?.itemAffiliateWebUrl || null;
+  const imageUrl =
+    raw?.image?.imageUrl ||
+    raw?.image?.imageUrl ||
+    (Array.isArray(raw?.additionalImages) ? raw.additionalImages[0]?.imageUrl : null) ||
+    null;
+  const sellerUser = raw?.seller?.username || raw?.seller?.userId || null;
+  const sellerScore = readNumber(raw?.seller?.feedbackScore) ?? null;
+  const sellerPct = readNumber(raw?.seller?.feedbackPercentage) ?? null;
+  const locationCc = raw?.itemLocation?.country || null;
+
+  const specs = normalizeSpecsFromTitle(title || '');
+  const model_key = normalizeModelKey(title || '');
+  const canonicalBrand = detectCanonicalBrand(title || '') || null;
+
+  return {
+    itemId,
+    title,
+    currency,
+    price,
+    shipping,
+    total,
+    condition,
+    url,
+    imageUrl,
+    sellerUser,
+    sellerScore,
+    sellerPct,
+    locationCc,
+    specs,
+    model_key,
+    canonicalBrand,
+  };
+}
+
+async function upsertItem(sql, snapshot) {
+  const {
+    itemId,
+    title,
+    canonicalBrand,
+    model_key,
+    specs,
+    currency,
+    sellerUser,
+    sellerScore,
+    sellerPct,
+    url,
+    imageUrl,
+  } = snapshot;
+
+  await sql`
+    INSERT INTO items (item_id, title, brand, model_key, head_type, dexterity, length_in, currency,
+                       seller_user, seller_score, seller_pct, url, image_url)
+    VALUES (
+      ${itemId},
+      ${title},
+      ${canonicalBrand},
+      ${model_key},
+      ${specs.headType},
+      ${specs.dexterity},
+      ${specs.length},
+      ${currency},
+      ${sellerUser},
+      ${sellerScore},
+      ${sellerPct},
+      ${url},
+      ${imageUrl}
+    )
+    ON CONFLICT (item_id) DO UPDATE
+      SET title = EXCLUDED.title,
+          brand = COALESCE(EXCLUDED.brand, items.brand),
+          model_key = EXCLUDED.model_key,
+          head_type = EXCLUDED.head_type,
+          dexterity = EXCLUDED.dexterity,
+          length_in = EXCLUDED.length_in,
+          currency = EXCLUDED.currency,
+          seller_user = EXCLUDED.seller_user,
+          seller_score = EXCLUDED.seller_score,
+          seller_pct = EXCLUDED.seller_pct,
+          url = EXCLUDED.url,
+          image_url = EXCLUDED.image_url,
+          updated_at = NOW()
+  `;
+}
+
+async function upsertPriceSnapshot(sql, snapshot, { existing, forceTouchObserved = false } = {}) {
+  const { itemId, price, shipping, total, condition, locationCc } = snapshot;
+
+  if (price == null) {
+    return { changed: false, skipped: true };
+  }
+
+  if (!existing) {
+    await sql`
+      INSERT INTO item_prices (item_id, price, shipping, total, condition, location_cc)
+      VALUES (
+        ${itemId},
+        ${price},
+        ${shipping},
+        ${total},
+        ${condition},
+        ${locationCc}
+      )
+      ON CONFLICT (item_id)
+      DO UPDATE
+        SET price = EXCLUDED.price,
+            shipping = EXCLUDED.shipping,
+            total = EXCLUDED.total,
+            condition = EXCLUDED.condition,
+            location_cc = EXCLUDED.location_cc,
+            observed_at = NOW()
+    `;
+    return { changed: true, skipped: false };
+  }
+
+  const prevPrice = existing.price != null ? readNumber(existing.price) : null;
+  const prevShipping = existing.shipping != null ? readNumber(existing.shipping) : null;
+  const prevTotal = existing.total != null ? readNumber(existing.total) : null;
+  const prevCondition = existing.condition || null;
+  const prevLocation = existing.location_cc || null;
+
+  const changed =
+    prevPrice !== price ||
+    prevShipping !== shipping ||
+    prevTotal !== total ||
+    prevCondition !== condition ||
+    prevLocation !== locationCc;
+
+  if (changed) {
+    await sql`
+      UPDATE item_prices
+         SET price = ${price},
+             shipping = ${shipping},
+             total = ${total},
+             condition = ${condition},
+             location_cc = ${locationCc},
+             observed_at = NOW()
+       WHERE item_id = ${itemId}
+    `;
+  } else if (forceTouchObserved) {
+    await sql`
+      UPDATE item_prices
+         SET observed_at = NOW()
+       WHERE item_id = ${itemId}
+    `;
+  }
+
+  return { changed, skipped: false };
+}
 function normalizeSpecsFromTitle(title = '') {
   // very light extraction; you can enrich later
   const t = (title || '').toLowerCase();
@@ -112,6 +273,28 @@ async function fetchEbayPage(token, q, { offset = 0, limit = 50, includeRefreshS
   return { items: merged, callCount, primaryCount };
 }
 
+async function fetchEbayItem(token, itemId) {
+  const res = await fetch(`https://api.ebay.com/buy/browse/v1/item/${itemId}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'X-EBAY-C-MARKETPLACE-ID': 'EBAY_US',
+    },
+  });
+
+  if (res.status === 404) {
+    return { item: null, callCount: 1 };
+  }
+
+  if (!res.ok) {
+    const txt = await res.text().catch(() => '');
+    throw new Error(`eBay ${res.status} ${res.statusText}${txt ? `: ${txt}` : ''}`);
+  }
+
+  const data = await res.json();
+  return { item: data, callCount: 1 };
+}
+
 export default async function handler(req, res) {
   try {
     if (!isAuthorized(req)) {
@@ -123,10 +306,111 @@ export default async function handler(req, res) {
 
     // Optional: run a single manual query with ?q=...
     const manualQ = (req.query?.q || '').trim() || null;
+    const refreshMode = req.query?.refresh === '1' || req.query?.mode === 'refresh';
     const queries = manualQ ? [manualQ] : SEED_QUERIES;
 
     const out = [];
     let totalCalls = 0;
+
+    if (refreshMode) {
+      const limitParam = Number.parseInt(req.query?.limit, 10);
+      const refreshLimit = Number.isFinite(limitParam) && limitParam > 0 ? Math.min(limitParam, 200) : 50;
+
+      const rows = await sql`
+        SELECT i.item_id,
+               i.title,
+               i.brand,
+               i.model_key,
+               i.head_type,
+               i.dexterity,
+               i.length_in,
+               i.currency,
+               i.seller_user,
+               i.seller_score,
+               i.seller_pct,
+               i.url,
+               i.image_url,
+               i.updated_at,
+               ip.price,
+               ip.shipping,
+               ip.total,
+               ip.condition,
+               ip.location_cc,
+               ip.observed_at
+          FROM items i
+     LEFT JOIN item_prices ip ON ip.item_id = i.item_id
+         ORDER BY COALESCE(ip.observed_at, i.updated_at) ASC NULLS FIRST
+         LIMIT ${refreshLimit}
+      `;
+
+      const refreshResults = [];
+      let refreshed = 0;
+      let changed = 0;
+      let missing = 0;
+
+      for (const row of rows) {
+        const itemId = row.item_id;
+        let error = null;
+        let status = 'ok';
+        let priceChanged = false;
+
+        try {
+          const { item, callCount } = await fetchEbayItem(token, itemId);
+          totalCalls += callCount;
+
+          if (!item) {
+            status = 'missing';
+            missing++;
+          } else {
+            const snapshot = extractListingSnapshot(item);
+
+            if (!snapshot || snapshot.price == null) {
+              status = 'skipped';
+            } else {
+              await upsertItem(sql, snapshot);
+              const existingPrice = row.observed_at
+                ? {
+                    price: row.price,
+                    shipping: row.shipping,
+                    total: row.total,
+                    condition: row.condition,
+                    location_cc: row.location_cc,
+                  }
+                : null;
+              const { changed: hasChanged } = await upsertPriceSnapshot(sql, snapshot, {
+                existing: existingPrice,
+                forceTouchObserved: true,
+              });
+
+              if (hasChanged) {
+                priceChanged = true;
+                changed++;
+              }
+
+              refreshed++;
+            }
+          }
+        } catch (e) {
+          error = e.message || String(e);
+          status = 'error';
+        }
+
+        refreshResults.push({ itemId, status, changed: priceChanged, error });
+      }
+
+      return res.status(200).json({
+        ok: true,
+        calls: totalCalls,
+        manualQ,
+        refresh: {
+          limit: refreshLimit,
+          refreshed,
+          changed,
+          missing,
+          results: refreshResults,
+        },
+      });
+    }
 
     for (const q of queries) {
       let inserted = 0;
@@ -165,81 +449,14 @@ export default async function handler(req, res) {
         await sql`BEGIN`;
 
         for (const it of allItems) {
-          const itemId = it?.itemId || it?.item_id;
-          const title = it?.title || null;
-          const currency =
-            it?.price?.currency || it?.price?.convertedFromCurrency || 'USD';
-          const price =
-            readNumber(it?.price?.value) ??
-            readNumber(it?.price?.convertedFromValue);
-          const shipping = pickShipping(it);
-          const total = price != null && shipping != null ? price + shipping : price ?? null;
-          const condition = it?.condition || null;
-          const url = it?.itemWebUrl || null;
-          const imageUrl = it?.image?.imageUrl || null;
+          const snapshot = extractListingSnapshot(it);
 
-          if (!itemId || price == null) {
+          if (!snapshot || snapshot.price == null) {
             continue; // skip incomplete
           }
 
-          const specs = normalizeSpecsFromTitle(title || '');
-          const model_key = normalizeModelKey(title || '');
-          const canonicalBrand = detectCanonicalBrand(title || '') || null;
-
-          // 1) upsert into items (unique catalog of listings)
-          await sql`
-            INSERT INTO items (item_id, title, brand, model_key, head_type, dexterity, length_in, currency,
-                               seller_user, seller_score, seller_pct, url, image_url)
-            VALUES (
-              ${itemId},
-              ${title},
-              ${canonicalBrand},
-              ${model_key},
-              ${specs.headType},
-              ${specs.dexterity},
-              ${specs.length},
-              ${currency},
-              ${it?.seller?.username || null},
-              ${it?.seller?.feedbackScore ?? null},
-              ${readNumber(it?.seller?.feedbackPercentage) ?? null},
-              ${url},
-              ${imageUrl}
-            )
-            ON CONFLICT (item_id) DO UPDATE
-              SET title = EXCLUDED.title,
-                  brand = COALESCE(EXCLUDED.brand, items.brand),
-                  model_key = EXCLUDED.model_key,
-                  head_type = EXCLUDED.head_type,
-                  dexterity = EXCLUDED.dexterity,
-                  length_in = EXCLUDED.length_in,
-                  currency = EXCLUDED.currency,
-                  seller_user = EXCLUDED.seller_user,
-                  seller_score = EXCLUDED.seller_score,
-                  seller_pct = EXCLUDED.seller_pct,
-                  url = EXCLUDED.url,
-                  image_url = EXCLUDED.image_url
-          `;
-
-          // 2) append a price snapshot
-          await sql`
-            INSERT INTO item_prices (item_id, price, shipping, total, condition, location_cc)
-            VALUES (
-              ${itemId},
-              ${price},
-              ${shipping},
-              ${total},
-              ${condition},
-              ${it?.itemLocation?.country || null}
-            )
-            ON CONFLICT (item_id)
-            DO UPDATE
-              SET price = EXCLUDED.price,
-                  shipping = EXCLUDED.shipping,
-                  total = EXCLUDED.total,
-                  condition = EXCLUDED.condition,
-                  location_cc = EXCLUDED.location_cc,
-                  observed_at = NOW()
-          `;
+          await upsertItem(sql, snapshot);
+          await upsertPriceSnapshot(sql, snapshot);
 
           inserted++;
         }


### PR DESCRIPTION
## Summary
- factor listing snapshot helpers so cron inserts and refreshes share normalization
- add a refresh mode that re-fetches stale items via the Browse get_item endpoint and updates observed_at
- touch items.updated_at and observed_at to keep deal lookbacks inside the active window

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68dad711a57c8325aaf16112a640ceda