### PR TITLE
Prefer leaderboard titles in Smart Price CTA links

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -283,11 +283,18 @@ export default async function Home() {
                   Number.isFinite(median) && Number.isFinite(deal.bestPrice) && median > 0
                     ? Math.round(((median - deal.bestPrice) / median) * 100)
                     : null;
-                const ctaQuery =
+                const displayedLabel =
+                  typeof deal?.label === "string" ? deal.label.trim() : "";
+                const bestOfferTitle =
+                  typeof deal?.bestOffer?.title === "string"
+                    ? deal.bestOffer.title.trim()
+                    : "";
+                const sanitizedFallback =
                   deal?.queryVariants?.clean ||
                   deal?.query ||
                   deal?.queryVariants?.accessory ||
                   "";
+                const ctaQuery = displayedLabel || bestOfferTitle || sanitizedFallback;
                 return (
                   <HighlightCard key={deal.query}>
                     <div className="aspect-[3/2] w-full bg-slate-100">


### PR DESCRIPTION
## Summary
- build Smart Price leaderboard CTA queries from the displayed card title when available
- keep the existing sanitized fallbacks when no title is present to prevent empty searches

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68db592235748325b4779ba136014f1d