### PR TITLE
Handle headcover queries in putter API search

### DIFF
--- a/pages/api/__tests__/putters.test.js
+++ b/pages/api/__tests__/putters.test.js
@@ -480,3 +480,135 @@ test("API handler keeps offers when titles omit filler descriptors", async () =>
     "headcover listing should survive query token filter"
   );
 });
+
+test("headcover queries broaden categories but still block other accessories", async () => {
+  const mod = await modulePromise;
+  const handler = mod.default;
+  assert.equal(typeof handler, "function", "default export should be a function");
+
+  const originalFetch = global.fetch;
+  const originalClientId = process.env.EBAY_CLIENT_ID;
+  const originalClientSecret = process.env.EBAY_CLIENT_SECRET;
+
+  process.env.EBAY_CLIENT_ID = "test-id";
+  process.env.EBAY_CLIENT_SECRET = "test-secret";
+
+  const browseItems = [
+    {
+      itemId: "hc-1",
+      title: "Scotty Cameron Putter Headcover - My Girl",
+      price: { value: "199", currency: "USD" },
+      itemWebUrl: "https://example.com/headcover",
+      seller: { username: "seller1" },
+      image: { imageUrl: "https://example.com/headcover.jpg" },
+      shippingOptions: [
+        { shippingCost: { value: "0", currency: "USD" } },
+      ],
+      buyingOptions: ["FIXED_PRICE"],
+      itemSpecifics: [],
+      localizedAspects: [],
+      additionalProductIdentities: [],
+      returnTerms: {},
+      itemLocation: {},
+    },
+    {
+      itemId: "hc-weights",
+      title: "Scotty Cameron Putter Headcover with 15g Weights",
+      price: { value: "225", currency: "USD" },
+      itemWebUrl: "https://example.com/headcover-weights",
+      seller: { username: "seller2" },
+      image: { imageUrl: "https://example.com/headcover-weights.jpg" },
+      shippingOptions: [
+        { shippingCost: { value: "12", currency: "USD" } },
+      ],
+      buyingOptions: ["FIXED_PRICE"],
+      itemSpecifics: [],
+      localizedAspects: [],
+      additionalProductIdentities: [],
+      returnTerms: {},
+      itemLocation: {},
+    },
+    {
+      itemId: "shaft-1",
+      title: "Scotty Cameron Putter Shaft Replacement",
+      price: { value: "80", currency: "USD" },
+      itemWebUrl: "https://example.com/shaft",
+      seller: { username: "seller3" },
+      image: { imageUrl: "https://example.com/shaft.jpg" },
+      shippingOptions: [
+        { shippingCost: { value: "8", currency: "USD" } },
+      ],
+      buyingOptions: ["FIXED_PRICE"],
+      itemSpecifics: [],
+      localizedAspects: [],
+      additionalProductIdentities: [],
+      returnTerms: {},
+      itemLocation: {},
+    },
+  ];
+
+  const browseCallParams = [];
+
+  global.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input?.toString();
+    if (!url) throw new Error("Missing URL in fetch stub");
+
+    if (url.includes("/identity/")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ access_token: "fake-token", expires_in: 7200 }),
+        text: async () => "",
+      };
+    }
+
+    if (url.startsWith("https://api.ebay.com/buy/browse/v1/item_summary/search")) {
+      browseCallParams.push(new URL(url));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ itemSummaries: browseItems, total: browseItems.length }),
+        text: async () => "",
+      };
+    }
+
+    throw new Error(`Unexpected fetch URL: ${url}`);
+  };
+
+  const req = {
+    method: "GET",
+    query: {
+      q: "Scotty Cameron headcover",
+      group: "false",
+      samplePages: "1",
+    },
+    headers: { host: "test.local", "user-agent": "node" },
+  };
+  const res = createMockRes();
+
+  try {
+    await handler(req, res);
+  } finally {
+    global.fetch = originalFetch;
+    process.env.EBAY_CLIENT_ID = originalClientId;
+    process.env.EBAY_CLIENT_SECRET = originalClientSecret;
+  }
+
+  assert.equal(res.statusCode, 200, "handler should respond with 200");
+  assert.ok(res.jsonBody, "response body should be captured");
+  assert.ok(Array.isArray(res.jsonBody.offers), "offers array should be present");
+  assert.equal(res.jsonBody.offers.length, 1, "only pure headcover listing should remain");
+  assert.equal(
+    res.jsonBody.offers[0]?.title,
+    "Scotty Cameron Putter Headcover - My Girl",
+    "headcover-only listing should remain after accessory guard"
+  );
+
+  assert.ok(browseCallParams.length > 0, "eBay Browse should be called at least once");
+  for (const callUrl of browseCallParams) {
+    const categoryIds = callUrl.searchParams.get("category_ids");
+    assert.ok(categoryIds, "category ids should be requested when forcing category");
+    assert.ok(categoryIds.includes("115280"), "golf club category should be enforced");
+    assert.ok(categoryIds.includes("36278"), "headcover category should be added for headcover queries");
+  }
+});


### PR DESCRIPTION
## Summary
- broaden the eBay Browse category filter to include headcovers when queries mention them while keeping pure putter searches scoped to golf clubs
- add headcover-aware filtering so broadened searches still exclude shafts, grips, and weight listings
- extend the API test suite with a headcover scenario that validates the new behaviour

## Testing
- node --test pages/api/__tests__/putters.test.js

------
https://chatgpt.com/codex/tasks/task_e_68db5ee244c48325890e51666dfab617