### PR TITLE
Filter accessory-heavy putter listings

### DIFF
--- a/pages/api/__tests__/putters.test.js
+++ b/pages/api/__tests__/putters.test.js
@@ -141,6 +141,23 @@ test("bid-only auction price fallback passes onlyComplete + hasBids", async () =
   assert.equal(hasBidsFiltered.length, 1, "hasBids filter should keep bid-only auction");
 });
 
+test("isLikelyPutter filters accessory-heavy titles but keeps headcovers", async () => {
+  const { __testables__ } = await modulePromise;
+  const { isLikelyPutter } = __testables__;
+
+  assert.equal(
+    isLikelyPutter({ title: "Scotty Cameron Putter Weight Kit" }),
+    false,
+    "weight kit title should be filtered"
+  );
+
+  assert.equal(
+    isLikelyPutter({ title: "Scotty Cameron Putter Headcover" }),
+    true,
+    "headcover title should still pass"
+  );
+});
+
 test("fetchEbayBrowse forwards supported sort options", async () => {
   const { fetchEbayBrowse } = await modulePromise;
 


### PR DESCRIPTION
## Summary
- tighten isLikelyPutter so accessory-dominated titles are filtered while preserving headcover detection
- expose isLikelyPutter to tests and add coverage for accessory filtering vs. headcover cases

## Testing
- node --test pages/api/__tests__/putters.test.js

------
https://chatgpt.com/codex/tasks/task_e_68db615df8c08325b6ed2debdf4b3eeb