### PR TITLE
Refactor affiliate decorator and cover top deals

### DIFF
--- a/lib/affiliate.js
+++ b/lib/affiliate.js
@@ -1,0 +1,45 @@
+const DEFAULT_EPN = {
+  toolid: "10001",
+  mkcid: "1",
+  mkrid: "711-53200-19255-0",
+  siteid: "0",
+  mkevt: "1",
+};
+
+function isEbayHost(hostname) {
+  if (!hostname) return false;
+  const h = hostname.toLowerCase();
+  if (h.includes("rover.ebay.")) return false;
+  return h.includes(".ebay.");
+}
+
+export function decorateEbayUrl(raw, overrides = {}) {
+  if (!raw) return raw;
+  try {
+    const u = new URL(raw);
+    if (!isEbayHost(u.hostname)) return raw;
+
+    const campid = overrides.campid ?? process.env.EPN_CAMPID ?? "";
+    if (!campid) return raw;
+
+    const params = {
+      mkcid: overrides.mkcid ?? process.env.EPN_MKCID ?? DEFAULT_EPN.mkcid,
+      mkrid: overrides.mkrid ?? process.env.EPN_MKRID ?? DEFAULT_EPN.mkrid,
+      siteid: overrides.siteid ?? process.env.EPN_SITEID ?? DEFAULT_EPN.siteid,
+      campid,
+      customid: overrides.customid ?? process.env.EPN_CUSTOMID ?? "",
+      toolid: overrides.toolid ?? process.env.EPN_TOOLID ?? DEFAULT_EPN.toolid,
+      mkevt: overrides.mkevt ?? process.env.EPN_MKEVT ?? DEFAULT_EPN.mkevt,
+    };
+
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== null && String(value).length) {
+        u.searchParams.set(key, String(value));
+      }
+    }
+
+    return u.toString();
+  } catch {
+    return raw;
+  }
+}

--- a/pages/api/putters.js
+++ b/pages/api/putters.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 
+import { decorateEbayUrl } from "../../lib/affiliate.js";
 import { containsAccessoryToken, stripAccessoryTokens } from "../../lib/sanitizeModelKey.js";
 
 /**
@@ -26,53 +27,6 @@ const CATEGORY_PUTTER_HEADCOVERS = "36278";
 const HEAD_COVER_TOKEN_VARIANTS = new Set(["headcover", "headcovers"]);
 const HEAD_COVER_TEXT_RX = /\bhead\s*cover(s)?\b|headcover(s)?/i;
 const ACCESSORY_BLOCK_PATTERN = /\b(shafts?|grips?|weights?)\b/i;
-
-// -------------------- EPN affiliate decorator --------------------
-const EPN = {
-  campid: process.env.EPN_CAMPID || "",
-  customid: process.env.EPN_CUSTOMID || "",
-  toolid: process.env.EPN_TOOLID || "10001",
-  mkcid: process.env.EPN_MKCID || "1",
-  mkrid: process.env.EPN_MKRID || "711-53200-19255-0",
-  siteid: process.env.EPN_SITEID || "0",
-  mkevt: process.env.EPN_MKEVT || "1",
-};
-
-function isEbayHost(hostname) {
-  if (!hostname) return false;
-  const h = hostname.toLowerCase();
-  if (h.includes("rover.ebay.")) return false; // let your direct ebay links remain direct
-  return h.includes(".ebay.");
-}
-
-function decorateEbayUrl(raw, overrides = {}) {
-  if (!raw) return raw;
-  try {
-    const u = new URL(raw);
-    if (!isEbayHost(u.hostname)) return raw;
-
-    const campid = overrides.campid ?? EPN.campid;
-    if (!campid) return raw;
-
-    const params = {
-      mkcid: overrides.mkcid ?? EPN.mkcid,
-      mkrid: overrides.mkrid ?? EPN.mkrid,
-      siteid: overrides.siteid ?? EPN.siteid,
-      campid,
-      customid: overrides.customid ?? EPN.customid,
-      toolid: overrides.toolid ?? EPN.toolid,
-      mkevt: overrides.mkevt ?? EPN.mkevt,
-    };
-    for (const [k, v] of Object.entries(params)) {
-      if (v !== undefined && v !== null && String(v).length) {
-        u.searchParams.set(k, String(v));
-      }
-    }
-    return u.toString();
-  } catch {
-    return raw;
-  }
-}
 
 // -------------------- Token --------------------
 let _tok = { val: null, exp: 0 };

--- a/pages/api/top-deals.js
+++ b/pages/api/top-deals.js
@@ -9,6 +9,7 @@ import {
   containsAccessoryToken,
   HEAD_COVER_TOKEN_VARIANTS,
 } from "../../lib/sanitizeModelKey.js";
+import { decorateEbayUrl } from "../../lib/affiliate.js";
 
 const CATALOG_LOOKUP = (() => {
   const map = new Map();
@@ -384,7 +385,7 @@ export function buildDealsFromRows(rows, limit, lookbackHours = null) {
     const bestOffer = {
       itemId: row.item_id,
       title: row.title,
-      url: row.url,
+      url: decorateEbayUrl(row.url),
       price,
       total,
       shipping,


### PR DESCRIPTION
## Summary
- extract the eBay affiliate URL decorator into a shared lib and reuse it in the putters and top deals APIs
- ensure leaderboard deals expose affiliate URLs and extend API coverage to validate the parameters when EPN env vars are set

## Testing
- node --test pages/api/__tests__/top-deals.test.js

------
https://chatgpt.com/codex/tasks/task_e_68db6f73f4e88325a21f3d38d87e8380