### PR TITLE
Sanitize deal CTA queries and add regression test

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -7,7 +7,7 @@ import SectionWrapper from "@/components/SectionWrapper";
 import HighlightCard from "@/components/HighlightCard";
 import PriceComparisonTable from "@/components/PriceComparisonTable";
 import TrendingSparkline from "@/components/TrendingSparkline";
-import { sanitizeModelKey } from "@/lib/sanitizeModelKey";
+import { buildDealCtaHref, sanitizeModelKey } from "@/lib/sanitizeModelKey";
 
 const DEFAULT_SNAPSHOT_QUERY = "golf putter";
 
@@ -289,12 +289,16 @@ export default async function Home() {
                   typeof deal?.bestOffer?.title === "string"
                     ? deal.bestOffer.title.trim()
                     : "";
-                const sanitizedFallback =
-                  deal?.queryVariants?.clean ||
-                  deal?.query ||
-                  deal?.queryVariants?.accessory ||
-                  "";
-                const ctaQuery = displayedLabel || bestOfferTitle || sanitizedFallback;
+                const { href: ctaHref } = buildDealCtaHref({
+                  ...deal,
+                  label: displayedLabel || deal?.label || "",
+                  bestOffer: deal?.bestOffer
+                    ? {
+                        ...deal.bestOffer,
+                        title: bestOfferTitle,
+                      }
+                    : null,
+                });
                 const bestOfferUrl =
                   typeof deal?.bestOffer?.url === "string" && deal.bestOffer.url.trim().length > 0
                     ? deal.bestOffer.url
@@ -355,7 +359,7 @@ export default async function Home() {
                       <div className="mt-auto">
                         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
                           <Link
-                            href={`/putters?q=${encodeURIComponent(ctaQuery)}`}
+                            href={ctaHref}
                             className="inline-flex items-center justify-center rounded-full bg-slate-900 px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700"
                           >
                             See the latest listings

--- a/lib/__tests__/buildDealCtaHref.test.js
+++ b/lib/__tests__/buildDealCtaHref.test.js
@@ -1,0 +1,39 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+const modulePath = path.join(__dirname, "..", "sanitizeModelKey.js");
+const moduleHref = pathToFileURL(modulePath).href;
+const modulePromise = import(moduleHref);
+
+test("buildDealCtaHref removes noisy tokens and preserves modelKey", async () => {
+  const { buildDealCtaHref } = await modulePromise;
+
+  const deal = {
+    modelKey: "SeeMore|Mini Giant|Deep Flange|Tour",
+    label: "SeeMore Mini Giant Deep Flange Tour 🟢 w/Headcover 34\"",
+    query: "SeeMore Mini Giant Deep Flange Tour 🟢 w/Headcover 34\"",
+    queryVariants: {
+      clean: "SeeMore Mini Giant Deep Flange Tour 🟢 w/Headcover 34\"",
+      accessory: "SeeMore Mini Giant Deep Flange Tour 🟢 w/Headcover 34\" 🎯",
+    },
+    bestOffer: {
+      title: "SeeMore Mini Giant Deep Flange Tour Putter 🟢 w/HC 34\"",
+    },
+  };
+
+  const { href, query } = buildDealCtaHref(deal);
+
+  assert.ok(query.includes("SeeMore"));
+  assert.ok(query.includes("Mini Giant Deep Flange Tour"));
+  assert.ok(/\bputter\b/i.test(query));
+  assert.ok(!/headcover/i.test(query), "expected accessory tokens to be removed");
+  assert.ok(!/🟢/.test(query), "expected emoji to be removed");
+  assert.ok(!/🎯/.test(query), "expected emoji from accessory variant to be removed");
+
+  const url = new URL(href, "https://example.com");
+  assert.equal(url.pathname, "/putters");
+  assert.equal(url.searchParams.get("modelKey"), deal.modelKey);
+  assert.equal(url.searchParams.get("q"), query);
+});

--- a/lib/sanitizeModelKey.js
+++ b/lib/sanitizeModelKey.js
@@ -242,6 +242,81 @@ export function stripAccessoryTokens(text = "") {
   return tokens.join(" ");
 }
 
+function removeEmojiAndPunctuation(text = "") {
+  if (!text) return "";
+  return String(text)
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/gu, "")
+    .replace(/\p{Extended_Pictographic}/gu, " ")
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function collapseShortTokens(text = "") {
+  if (!text) return "";
+  const tokens = text
+    .split(/\s+/)
+    .filter((token) => {
+      if (!token) return false;
+      if (/\d/.test(token)) return true;
+      return token.length > 1;
+    });
+  return tokens.join(" ");
+}
+
+export function deriveDealSearchPhrase(deal = {}, fallback = "golf putter") {
+  const candidates = [];
+  const pushCandidate = (value) => {
+    if (typeof value !== "string") return;
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    candidates.push(trimmed);
+  };
+
+  pushCandidate(deal?.queryVariants?.clean);
+  pushCandidate(deal?.query);
+  pushCandidate(deal?.queryVariants?.accessory);
+  pushCandidate(deal?.bestOffer?.title);
+  pushCandidate(deal?.label);
+
+  const seen = new Set();
+  for (const raw of candidates) {
+    if (seen.has(raw)) continue;
+    seen.add(raw);
+    let cleaned = removeEmojiAndPunctuation(raw);
+    cleaned = stripAccessoryTokens(cleaned);
+    cleaned = collapseShortTokens(cleaned);
+    cleaned = cleaned.replace(/\s+/g, " ").trim();
+    if (!cleaned) continue;
+    if (!/\bputter\b/i.test(cleaned)) {
+      cleaned = `${cleaned} putter`;
+    }
+    cleaned = cleaned.replace(/\s+/g, " ").trim();
+    if (cleaned) return cleaned;
+  }
+
+  if (fallback) {
+    return deriveDealSearchPhrase({ query: fallback }, "");
+  }
+
+  return "";
+}
+
+export function buildDealCtaHref(deal = {}, fallback = "golf putter") {
+  const query = deriveDealSearchPhrase(deal, fallback);
+  const params = new URLSearchParams();
+  const modelKey = typeof deal?.modelKey === "string" ? deal.modelKey.trim() : "";
+  if (query) params.set("q", query);
+  if (modelKey) params.set("modelKey", modelKey);
+  const qs = params.toString();
+  return {
+    query,
+    modelKey,
+    href: qs ? `/putters?${qs}` : "/putters",
+  };
+}
+
 /**
  * Examples:
  * sanitizeModelKey("Titleist|Scotty Cameron|Super Select|Cameron");


### PR DESCRIPTION
## Summary
- add helpers to strip emoji/punctuation/accessory tokens from deal queries and append the model key to CTA params
- update the homepage deal CTA to use the shared helper so links fall back cleanly to normalized metadata
- cover the CTA behaviour with a regression test to ensure noisy tokens are removed while model key is preserved

## Testing
- node --test lib/__tests__/buildDealCtaHref.test.js pages/api/__tests__/*.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc0c8f1c9c8325b91f890f36ee8016