### PR TITLE
Preserve brand tokens in deal search phrase

### DIFF
--- a/lib/__tests__/buildDealCtaHref.test.js
+++ b/lib/__tests__/buildDealCtaHref.test.js
@@ -37,3 +37,51 @@ test("buildDealCtaHref removes noisy tokens and preserves modelKey", async () =>
   assert.equal(url.searchParams.get("modelKey"), deal.modelKey);
   assert.equal(url.searchParams.get("q"), query);
 });
+
+test("buildDealCtaHref prefers sanitized search phrase retaining brand tokens", async () => {
+  const { buildDealCtaHref } = await modulePromise;
+
+  const scenarios = [
+    {
+      label: "Titleist Scotty Cameron Phantom X 5",
+      deal: {
+        modelKey: "Titleist|Scotty Cameron|Phantom X 5",
+        label: "Titleist Scotty Cameron Phantom X 5",
+        query: "Phantom X 5",
+        queryVariants: {
+          clean: "Phantom X 5",
+          accessory: "Titleist Scotty Cameron Phantom X 5 Headcover",
+        },
+        bestOffer: {
+          title: "Titleist Scotty Cameron Phantom X 5 Putter",
+        },
+      },
+      expected: /\btitleist\b/i,
+    },
+    {
+      label: "Ping PLD Anser 4",
+      deal: {
+        modelKey: "Ping|PLD|Anser 4",
+        label: "Ping PLD Anser 4",
+        query: "PLD Anser 4",
+        queryVariants: {
+          clean: "PLD Anser 4",
+          accessory: "Ping PLD Anser 4 Headcover",
+        },
+        bestOffer: {
+          title: "Ping PLD Anser 4 Putter",
+        },
+      },
+      expected: /\bping\b/i,
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const { query } = buildDealCtaHref(scenario.deal);
+    assert.match(
+      query,
+      scenario.expected,
+      `expected query for ${scenario.label} to include the brand token`
+    );
+  }
+});

--- a/lib/sanitizeModelKey.js
+++ b/lib/sanitizeModelKey.js
@@ -265,13 +265,58 @@ function collapseShortTokens(text = "") {
   return tokens.join(" ");
 }
 
+function sanitizeCandidate(raw = "") {
+  let cleaned = removeEmojiAndPunctuation(raw);
+  cleaned = stripAccessoryTokens(cleaned);
+  cleaned = collapseShortTokens(cleaned);
+  cleaned = cleaned.replace(/\s+/g, " ").trim();
+  if (!cleaned) return "";
+  if (!/\bputter\b/i.test(cleaned)) {
+    cleaned = `${cleaned} putter`;
+  }
+  return cleaned.replace(/\s+/g, " ").trim();
+}
+
+function sanitizeForTokens(raw = "") {
+  let cleaned = removeEmojiAndPunctuation(raw);
+  cleaned = stripAccessoryTokens(cleaned);
+  cleaned = collapseShortTokens(cleaned);
+  return cleaned.replace(/\s+/g, " ").trim();
+}
+
+function extractTokens(text = "") {
+  return String(text)
+    .split(/\s+/)
+    .map((token) => token.toLowerCase())
+    .filter((token) => token && token !== "putter");
+}
+
+function buildReferenceTokens(deal = {}) {
+  const tokenSources = [
+    deal?.label,
+    deal?.bestOffer?.title,
+    deal?.modelKey,
+    deal?.queryVariants?.clean,
+    deal?.queryVariants?.accessory,
+    deal?.query,
+  ];
+  const tokens = new Set();
+  tokenSources.forEach((source) => {
+    if (typeof source !== "string") return;
+    const cleaned = sanitizeForTokens(source);
+    if (!cleaned) return;
+    extractTokens(cleaned).forEach((token) => tokens.add(token));
+  });
+  return tokens;
+}
+
 export function deriveDealSearchPhrase(deal = {}, fallback = "golf putter") {
-  const candidates = [];
+  const rawCandidates = [];
   const pushCandidate = (value) => {
     if (typeof value !== "string") return;
     const trimmed = value.trim();
     if (!trimmed) return;
-    candidates.push(trimmed);
+    rawCandidates.push(trimmed);
   };
 
   pushCandidate(deal?.queryVariants?.clean);
@@ -280,20 +325,46 @@ export function deriveDealSearchPhrase(deal = {}, fallback = "golf putter") {
   pushCandidate(deal?.bestOffer?.title);
   pushCandidate(deal?.label);
 
-  const seen = new Set();
-  for (const raw of candidates) {
-    if (seen.has(raw)) continue;
-    seen.add(raw);
-    let cleaned = removeEmojiAndPunctuation(raw);
-    cleaned = stripAccessoryTokens(cleaned);
-    cleaned = collapseShortTokens(cleaned);
-    cleaned = cleaned.replace(/\s+/g, " ").trim();
-    if (!cleaned) continue;
-    if (!/\bputter\b/i.test(cleaned)) {
-      cleaned = `${cleaned} putter`;
+  const seenRaw = new Set();
+  const sanitizedCandidates = [];
+  const seenClean = new Set();
+
+  for (const raw of rawCandidates) {
+    if (seenRaw.has(raw)) continue;
+    seenRaw.add(raw);
+    const cleaned = sanitizeCandidate(raw);
+    if (!cleaned || seenClean.has(cleaned)) continue;
+    seenClean.add(cleaned);
+    sanitizedCandidates.push(cleaned);
+  }
+
+  if (sanitizedCandidates.length) {
+    const referenceTokens = buildReferenceTokens(deal);
+    if (referenceTokens.size) {
+      let best = null;
+      sanitizedCandidates.forEach((cleaned, index) => {
+        const candidateTokens = new Set(extractTokens(cleaned));
+        let score = 0;
+        referenceTokens.forEach((token) => {
+          if (candidateTokens.has(token)) {
+            score += 1;
+          }
+        });
+        if (score > 0) {
+          if (
+            !best ||
+            score > best.score ||
+            (score === best.score && index < best.index)
+          ) {
+            best = { cleaned, score, index };
+          }
+        }
+      });
+      if (best) {
+        return best.cleaned;
+      }
     }
-    cleaned = cleaned.replace(/\s+/g, " ").trim();
-    if (cleaned) return cleaned;
+    return sanitizedCandidates[0];
   }
 
   if (fallback) {


### PR DESCRIPTION
## Summary
- refine deriveDealSearchPhrase to sanitize all candidates and prefer results that retain brand/model tokens from deal metadata
- add regression tests covering multiple brands when the clean variant omits the brand name

## Testing
- node --test lib/__tests__/buildDealCtaHref.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc15814bf08325ad07ebf4d3895967