### PR TITLE
Preserve headcover tokens in deal queries

### DIFF
--- a/lib/__tests__/buildDealCtaHref.test.js
+++ b/lib/__tests__/buildDealCtaHref.test.js
@@ -28,7 +28,7 @@ test("buildDealCtaHref removes noisy tokens and preserves modelKey", async () =>
   assert.ok(query.includes("SeeMore"));
   assert.ok(query.includes("Mini Giant Deep Flange Tour"));
   assert.ok(/\bputter\b/i.test(query));
-  assert.ok(!/headcover/i.test(query), "expected accessory tokens to be removed");
+  assert.ok(/headcover/i.test(query), "expected headcover tokens to be preserved");
   assert.ok(!/🟢/.test(query), "expected emoji to be removed");
   assert.ok(!/🎯/.test(query), "expected emoji from accessory variant to be removed");
 
@@ -84,4 +84,23 @@ test("buildDealCtaHref prefers sanitized search phrase retaining brand tokens", 
       `expected query for ${scenario.label} to include the brand token`
     );
   }
+});
+
+test("buildDealCtaHref keeps headcover token for headcover-only deals", async () => {
+  const { buildDealCtaHref } = await modulePromise;
+
+  const deal = {
+    modelKey: "Titleist|Scotty Cameron|Special Select|Headcover",
+    label: "Scotty Cameron Special Select Headcover",
+    query: "Scotty Cameron Special Select Headcover",
+    queryVariants: {
+      clean: "Scotty Cameron Special Select Headcover",
+      accessory: "Scotty Cameron Special Select Headcover",
+    },
+  };
+
+  const { query } = buildDealCtaHref(deal);
+
+  assert.match(query, /\bheadcovers?\b/i);
+  assert.match(query, /\bputter\b/i);
 });

--- a/lib/sanitizeModelKey.js
+++ b/lib/sanitizeModelKey.js
@@ -117,6 +117,14 @@ export function containsAccessoryToken(text = "") {
     .some((token) => isAccessoryToken(token));
 }
 
+function containsHeadCoverToken(text = "") {
+  if (!text) return false;
+  return String(text)
+    .split(/\s+/)
+    .filter(Boolean)
+    .some((token) => HEAD_COVER_TOKEN_VARIANTS.has(token.toLowerCase()));
+}
+
 function buildQueryVariant({
   labelForTokens = "",
   fallbackText = "",
@@ -233,12 +241,18 @@ export function detectCanonicalBrand(rawKey = "") {
   return detected || null;
 }
 
-export function stripAccessoryTokens(text = "") {
+export function stripAccessoryTokens(text = "", options = {}) {
+  const { preserveHeadCover = false } = options || {};
   if (!text) return "";
   const tokens = String(text)
     .split(/\s+/)
     .filter(Boolean)
-    .filter((token) => !isAccessoryToken(token));
+    .filter((token) => {
+      if (preserveHeadCover && HEAD_COVER_TOKEN_VARIANTS.has(token.toLowerCase())) {
+        return true;
+      }
+      return !isAccessoryToken(token);
+    });
   return tokens.join(" ");
 }
 
@@ -267,7 +281,8 @@ function collapseShortTokens(text = "") {
 
 function sanitizeCandidate(raw = "") {
   let cleaned = removeEmojiAndPunctuation(raw);
-  cleaned = stripAccessoryTokens(cleaned);
+  const preserveHeadCover = containsHeadCoverToken(cleaned);
+  cleaned = stripAccessoryTokens(cleaned, { preserveHeadCover });
   cleaned = collapseShortTokens(cleaned);
   cleaned = cleaned.replace(/\s+/g, " ").trim();
   if (!cleaned) return "";
@@ -277,9 +292,9 @@ function sanitizeCandidate(raw = "") {
   return cleaned.replace(/\s+/g, " ").trim();
 }
 
-function sanitizeForTokens(raw = "") {
+function sanitizeForTokens(raw = "", options = {}) {
   let cleaned = removeEmojiAndPunctuation(raw);
-  cleaned = stripAccessoryTokens(cleaned);
+  cleaned = stripAccessoryTokens(cleaned, options);
   cleaned = collapseShortTokens(cleaned);
   return cleaned.replace(/\s+/g, " ").trim();
 }
@@ -303,7 +318,7 @@ function buildReferenceTokens(deal = {}) {
   const tokens = new Set();
   tokenSources.forEach((source) => {
     if (typeof source !== "string") return;
-    const cleaned = sanitizeForTokens(source);
+    const cleaned = sanitizeForTokens(source, { preserveHeadCover: true });
     if (!cleaned) return;
     extractTokens(cleaned).forEach((token) => tokens.add(token));
   });


### PR DESCRIPTION
## Summary
- allow sanitizeCandidate to retain headcover tokens while still appending "putter"
- keep headcover tokens when collecting reference terms so headcover-aware queries win scoring
- add regression coverage ensuring headcover-only deals keep their headcover token in the CTA query

## Testing
- node --test lib/__tests__/buildDealCtaHref.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc19706bc88325b25354766de95a7c