### PR TITLE
Handle head cover tokens in query filtering

### DIFF
--- a/pages/api/__tests__/putters.test.js
+++ b/pages/api/__tests__/putters.test.js
@@ -498,6 +498,93 @@ test("API handler keeps offers when titles omit filler descriptors", async () =>
   );
 });
 
+test("head cover query matches combined headcover token", async () => {
+  const mod = await modulePromise;
+  const handler = mod.default;
+  assert.equal(typeof handler, "function", "default export should be a function");
+
+  const originalFetch = global.fetch;
+  const originalClientId = process.env.EBAY_CLIENT_ID;
+  const originalClientSecret = process.env.EBAY_CLIENT_SECRET;
+
+  process.env.EBAY_CLIENT_ID = "test-id";
+  process.env.EBAY_CLIENT_SECRET = "test-secret";
+
+  const browseItems = [
+    {
+      itemId: "ks1-headcover",
+      title: "Kirkland KS1 Putter Headcover",
+      price: { value: "45", currency: "USD" },
+      itemWebUrl: "https://example.com/ks1-headcover",
+      seller: { username: "kirkland-seller" },
+      image: { imageUrl: "https://example.com/ks1-headcover.jpg" },
+      shippingOptions: [
+        { shippingCost: { value: "0", currency: "USD" } },
+      ],
+      buyingOptions: ["FIXED_PRICE"],
+      itemSpecifics: [],
+      localizedAspects: [],
+      additionalProductIdentities: [],
+      returnTerms: {},
+      itemLocation: {},
+    },
+  ];
+
+  global.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input?.toString();
+    if (!url) throw new Error("Missing URL in fetch stub");
+
+    if (url.includes("/identity/")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ access_token: "fake-token", expires_in: 7200 }),
+        text: async () => "",
+      };
+    }
+
+    if (url.startsWith("https://api.ebay.com/buy/browse/v1/item_summary/search")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ itemSummaries: browseItems, total: browseItems.length }),
+        text: async () => "",
+      };
+    }
+
+    throw new Error(`Unexpected fetch URL: ${url}`);
+  };
+
+  const req = {
+    method: "GET",
+    query: {
+      q: "kirkland signature ks1 head cover",
+      group: "false",
+      forceCategory: "false",
+    },
+    headers: { host: "test.local", "user-agent": "node" },
+  };
+  const res = createMockRes();
+
+  try {
+    await handler(req, res);
+  } finally {
+    global.fetch = originalFetch;
+    process.env.EBAY_CLIENT_ID = originalClientId;
+    process.env.EBAY_CLIENT_SECRET = originalClientSecret;
+  }
+
+  assert.equal(res.statusCode, 200, "handler should respond with 200");
+  assert.ok(res.jsonBody, "response body should be captured");
+  assert.ok(Array.isArray(res.jsonBody.offers), "offers array should be present");
+  assert.equal(res.jsonBody.offers.length, 1, "headcover listing should survive token filtering");
+  assert.equal(
+    res.jsonBody.offers[0]?.title,
+    "Kirkland KS1 Putter Headcover",
+    "head cover query should match combined headcover token"
+  );
+});
+
 test("headcover queries broaden categories but still block other accessories", async () => {
   const mod = await modulePromise;
   const handler = mod.default;


### PR DESCRIPTION
## Summary
- ensure tokenization adds headcover variants and treat "signature" as a trivial query token
- adjust query token normalization so head cover phrases drop fragment tokens while keeping the combined variant
- add a regression test covering a "kirkland signature ks1 head cover" query that should match headcover listings

## Testing
- node --test pages/api/__tests__/putters.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc1ed668408325808ae56718779240