### PR TITLE
Handle punctuated headcover tokens

### DIFF
--- a/pages/api/__tests__/putters.test.js
+++ b/pages/api/__tests__/putters.test.js
@@ -158,6 +158,22 @@ test("isLikelyPutter filters accessory-heavy titles but keeps headcovers", async
   );
 });
 
+test("tokenize + queryMentionsHeadcover handle punctuated head cover text", async () => {
+  const { tokenize, __testables__ } = await modulePromise;
+  const tokens = tokenize("Deluxe Putter Head-Cover");
+  assert.ok(tokens.includes("headcover"), "hyphenated head cover should produce headcover token");
+
+  const { queryMentionsHeadcover } = __testables__;
+  assert.ok(
+    typeof queryMentionsHeadcover === "function",
+    "queryMentionsHeadcover should be exposed via __testables__"
+  );
+  assert.ok(
+    queryMentionsHeadcover("Premium Head/Cover Protector"),
+    "queryMentionsHeadcover should treat punctuation like whitespace"
+  );
+});
+
 test("fetchEbayBrowse forwards supported sort options", async () => {
   const { fetchEbayBrowse } = await modulePromise;
 
@@ -513,7 +529,7 @@ test("head cover query matches combined headcover token", async () => {
   const browseItems = [
     {
       itemId: "ks1-headcover",
-      title: "Kirkland KS1 Putter Headcover",
+      title: "Kirkland KS-1 Putter Head-Cover",
       price: { value: "45", currency: "USD" },
       itemWebUrl: "https://example.com/ks1-headcover",
       seller: { username: "kirkland-seller" },
@@ -558,7 +574,7 @@ test("head cover query matches combined headcover token", async () => {
   const req = {
     method: "GET",
     query: {
-      q: "kirkland signature ks1 head cover",
+      q: "kirkland signature ks1 head cover putter",
       group: "false",
       forceCategory: "false",
     },
@@ -580,7 +596,7 @@ test("head cover query matches combined headcover token", async () => {
   assert.equal(res.jsonBody.offers.length, 1, "headcover listing should survive token filtering");
   assert.equal(
     res.jsonBody.offers[0]?.title,
-    "Kirkland KS1 Putter Headcover",
+    "Kirkland KS-1 Putter Head-Cover",
     "head cover query should match combined headcover token"
   );
 });

--- a/pages/api/putters.js
+++ b/pages/api/putters.js
@@ -25,7 +25,7 @@ const EBAY_SITE = process.env.EBAY_SITE || "EBAY_US";
 const CATEGORY_GOLF_CLUBS = "115280";
 const CATEGORY_PUTTER_HEADCOVERS = "36278";
 const HEAD_COVER_TOKEN_VARIANTS = new Set(["headcover", "headcovers"]);
-const HEAD_COVER_TEXT_RX = /\bhead\s*cover(s)?\b|headcover(s)?/i;
+const HEAD_COVER_TEXT_RX = /\bhead(?:[\s/_-]*?)cover(s)?\b|headcover(s)?/i;
 const ACCESSORY_BLOCK_PATTERN = /\b(shafts?|grips?|weights?)\b/i;
 
 // -------------------- Token --------------------
@@ -101,12 +101,12 @@ const tokenize = (s) => {
     tokenSet.add(match[0]);
   }
 
-  const letterDigitWithGap = /([a-z])\s+([0-9]+)/g;
+  const letterDigitWithGap = /([a-z]+)(?:[\s/_-]+)([0-9]+)/g;
   while ((match = letterDigitWithGap.exec(normalized))) {
     tokenSet.add(`${match[1]}${match[2]}`);
   }
 
-  const digitLetterWithGap = /([0-9]+)\s+([a-z])/g;
+  const digitLetterWithGap = /([0-9]+)(?:[\s/_-]+)([a-z]+)/g;
   while ((match = digitLetterWithGap.exec(normalized))) {
     tokenSet.add(`${match[1]}${match[2]}`);
   }
@@ -451,7 +451,7 @@ function mapEbayItemToOffer(item) {
   };
 }
 
-const __testables__ = { normalizeBuyingOptions, isLikelyPutter };
+const __testables__ = { normalizeBuyingOptions, isLikelyPutter, queryMentionsHeadcover };
 
 export { tokenize, mapEbayItemToOffer, fetchEbayBrowse, __testables__ };
 
@@ -884,7 +884,12 @@ export default async function handler(req, res) {
               if (t === "head" || t === "cover" || t === "covers" || t === "headcovers") {
                 return false;
               }
-              if (/^[0-9]+[hc]$/.test(t) || /^[hc][0-9]+$/.test(t)) {
+              if (
+                /^[0-9]+[hc]$/.test(t) ||
+                /^[hc][0-9]+$/.test(t) ||
+                /^[0-9]+(?:head|cover|covers)$/.test(t) ||
+                /^(?:head|cover|covers)[0-9]+$/.test(t)
+              ) {
                 return false;
               }
             }


### PR DESCRIPTION
## Summary
- normalize "head cover" detection so punctuation between the words still yields headcover tokens and expose the helper for testing
- expand token combination rules to bridge punctuation-separated letter/digit pairs and relax headcover query filters to drop noisy numeric variants
- cover hyphenated headcover cases in API tests, including a regression for Kirkland KS-1 listings

## Testing
- node --test pages/api/__tests__/putters.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc236dd870832581e9d116af8030a7