### PR TITLE
Handle headcover-only deal queries

### DIFF
--- a/lib/__tests__/buildDealCtaHref.test.js
+++ b/lib/__tests__/buildDealCtaHref.test.js
@@ -102,5 +102,48 @@ test("buildDealCtaHref keeps headcover token for headcover-only deals", async ()
   const { query } = buildDealCtaHref(deal);
 
   assert.match(query, /\bheadcovers?\b/i);
-  assert.match(query, /\bputter\b/i);
+  assert.ok(!/\bputter\b/i.test(query), "expected synthetic putter keyword to be removed");
+});
+
+test("buildDealCtaHref strips trailing putter token for headcover-only deals", async () => {
+  const { buildDealCtaHref } = await modulePromise;
+
+  const deal = {
+    modelKey: "Titleist|Scotty Cameron|Studio Style|Headcover",
+    label: "Scotty Cameron Studio Style Headcover - Blue", // no putter token present
+    query: "Scotty Cameron Studio Style Headcover - Blue",
+    queryVariants: {
+      clean: "Scotty Cameron Studio Style Headcover - Blue",
+      accessory: "Scotty Cameron Studio Style Headcover - Blue",
+    },
+    bestOffer: { title: "Scotty Cameron Studio Style Headcover - Blue" },
+  };
+
+  const { query } = buildDealCtaHref(deal);
+
+  assert.match(query, /\bheadcovers?\b/i);
+  assert.ok(!/\bputter\b/i.test(query), "expected trailing putter token to be stripped");
+  assert.ok(/studio style/i.test(query), "expected model tokens to persist");
+});
+
+test("buildDealCtaHref retains putter keyword when deal data includes putter", async () => {
+  const { buildDealCtaHref } = await modulePromise;
+
+  const deal = {
+    modelKey: "SeeMore|Mini Giant|Deep Flange|Tour",
+    label: "SeeMore Mini Giant Deep Flange Tour w/ Headcover 34\"",
+    query: "SeeMore Mini Giant Deep Flange Tour w/ Headcover 34\"",
+    queryVariants: {
+      clean: "SeeMore Mini Giant Deep Flange Tour w/ Headcover 34\"",
+      accessory: "SeeMore Mini Giant Deep Flange Tour w/ Headcover 34\"",
+    },
+    bestOffer: {
+      title: "SeeMore Mini Giant Deep Flange Tour Putter w/ Headcover 34\"",
+    },
+  };
+
+  const { query } = buildDealCtaHref(deal);
+
+  assert.match(query, /\bheadcover\b/i);
+  assert.match(query, /\bputter\b/i, "expected putter keyword to remain for true putter deal");
 });

--- a/lib/sanitizeModelKey.js
+++ b/lib/sanitizeModelKey.js
@@ -390,7 +390,31 @@ export function deriveDealSearchPhrase(deal = {}, fallback = "golf putter") {
 }
 
 export function buildDealCtaHref(deal = {}, fallback = "golf putter") {
-  const query = deriveDealSearchPhrase(deal, fallback);
+  let query = deriveDealSearchPhrase(deal, fallback);
+
+  if (query) {
+    const sourceTexts = [
+      deal?.label,
+      deal?.query,
+      deal?.modelKey,
+      deal?.bestOffer?.title,
+      deal?.queryVariants?.clean,
+      deal?.queryVariants?.accessory,
+    ];
+    const hasPutterSource = sourceTexts.some(
+      (text) => typeof text === "string" && /\bputter\b/i.test(text)
+    );
+    if (!hasPutterSource && containsHeadCoverToken(query)) {
+      const strippedQuery = query
+        .replace(/(?:\s*\bputter\b)+$/gi, "")
+        .replace(/\s+/g, " ")
+        .trim();
+      if (strippedQuery) {
+        query = strippedQuery;
+      }
+    }
+  }
+
   const params = new URLSearchParams();
   const modelKey = typeof deal?.modelKey === "string" ? deal.modelKey.trim() : "";
   if (query) params.set("q", query);


### PR DESCRIPTION
## Summary
- strip trailing "putter" tokens from headcover-only CTA queries while leaving true putter deals untouched
- expand buildDealCtaHref tests to cover headcover-only queries and putter retention behavior

## Testing
- node --test lib/__tests__/buildDealCtaHref.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc2f392e0883258a8a6d6db36d8ea5