### PR TITLE
Handle spaced head cover tokens

### DIFF
--- a/lib/__tests__/buildDealCtaHref.test.js
+++ b/lib/__tests__/buildDealCtaHref.test.js
@@ -7,6 +7,8 @@ const modulePath = path.join(__dirname, "..", "sanitizeModelKey.js");
 const moduleHref = pathToFileURL(modulePath).href;
 const modulePromise = import(moduleHref);
 
+const HEAD_COVER_REGEX = /\bhead(?:\s|-)?covers?\b/i;
+
 test("buildDealCtaHref removes noisy tokens and preserves modelKey", async () => {
   const { buildDealCtaHref } = await modulePromise;
 
@@ -28,7 +30,10 @@ test("buildDealCtaHref removes noisy tokens and preserves modelKey", async () =>
   assert.ok(query.includes("SeeMore"));
   assert.ok(query.includes("Mini Giant Deep Flange Tour"));
   assert.ok(/\bputter\b/i.test(query));
-  assert.ok(/headcover/i.test(query), "expected headcover tokens to be preserved");
+  assert.ok(
+    HEAD_COVER_REGEX.test(query),
+    "expected headcover tokens to be preserved"
+  );
   assert.ok(!/🟢/.test(query), "expected emoji to be removed");
   assert.ok(!/🎯/.test(query), "expected emoji from accessory variant to be removed");
 
@@ -101,7 +106,7 @@ test("buildDealCtaHref keeps headcover token for headcover-only deals", async ()
 
   const { query } = buildDealCtaHref(deal);
 
-  assert.match(query, /\bheadcovers?\b/i);
+  assert.match(query, HEAD_COVER_REGEX);
   assert.ok(!/\bputter\b/i.test(query), "expected synthetic putter keyword to be removed");
 });
 
@@ -110,18 +115,18 @@ test("buildDealCtaHref strips trailing putter token for headcover-only deals", a
 
   const deal = {
     modelKey: "Titleist|Scotty Cameron|Studio Style|Headcover",
-    label: "Scotty Cameron Studio Style Headcover - Blue", // no putter token present
-    query: "Scotty Cameron Studio Style Headcover - Blue",
+    label: "Scotty Cameron Studio Style Head Cover - Blue", // no putter token present
+    query: "Scotty Cameron Studio Style Head Cover - Blue",
     queryVariants: {
-      clean: "Scotty Cameron Studio Style Headcover - Blue",
-      accessory: "Scotty Cameron Studio Style Headcover - Blue",
+      clean: "Scotty Cameron Studio Style Head Cover - Blue",
+      accessory: "Scotty Cameron Studio Style Head Cover - Blue",
     },
     bestOffer: { title: "Scotty Cameron Studio Style Headcover - Blue" },
   };
 
   const { query } = buildDealCtaHref(deal);
 
-  assert.match(query, /\bheadcovers?\b/i);
+  assert.match(query, HEAD_COVER_REGEX);
   assert.ok(!/\bputter\b/i.test(query), "expected trailing putter token to be stripped");
   assert.ok(/studio style/i.test(query), "expected model tokens to persist");
 });
@@ -144,6 +149,6 @@ test("buildDealCtaHref retains putter keyword when deal data includes putter", a
 
   const { query } = buildDealCtaHref(deal);
 
-  assert.match(query, /\bheadcover\b/i);
+  assert.match(query, HEAD_COVER_REGEX);
   assert.match(query, /\bputter\b/i, "expected putter keyword to remain for true putter deal");
 });

--- a/lib/sanitizeModelKey.js
+++ b/lib/sanitizeModelKey.js
@@ -36,6 +36,8 @@ export const HEAD_COVER_TOKEN_VARIANTS = new Set([
   "headcovers",
 ]);
 
+const HEAD_COVER_PATTERN = /head[\s-]*covers?/i;
+
 const ACCESSORY_EXACT_TOKENS = new Set(
   [
     "adapter",
@@ -119,7 +121,11 @@ export function containsAccessoryToken(text = "") {
 
 function containsHeadCoverToken(text = "") {
   if (!text) return false;
-  return String(text)
+  const normalizedText = String(text);
+  if (HEAD_COVER_PATTERN.test(normalizedText)) {
+    return true;
+  }
+  return normalizedText
     .split(/\s+/)
     .filter(Boolean)
     .some((token) => HEAD_COVER_TOKEN_VARIANTS.has(token.toLowerCase()));


### PR DESCRIPTION
## Summary
- expand the headcover token detection to catch spaced or hyphenated variants
- update CTA unit tests to use a shared headcover regex and cover spaced "Head Cover" labels

## Testing
- node --test lib/__tests__/buildDealCtaHref.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc39c4cee08325a853dff7c897cf11