### PR TITLE
Relax headcover token filtering

### DIFF
--- a/pages/api/__tests__/putters.test.js
+++ b/pages/api/__tests__/putters.test.js
@@ -717,6 +717,93 @@ test("API handler keeps offers when titles omit filler descriptors", async () =>
   );
 });
 
+test("headcover queries ignore length/dex tokens during filtering", async () => {
+  const mod = await modulePromise;
+  const handler = mod.default;
+  assert.equal(typeof handler, "function", "default export should be a function");
+
+  const originalFetch = global.fetch;
+  const originalClientId = process.env.EBAY_CLIENT_ID;
+  const originalClientSecret = process.env.EBAY_CLIENT_SECRET;
+
+  process.env.EBAY_CLIENT_ID = "test-id";
+  process.env.EBAY_CLIENT_SECRET = "test-secret";
+
+  const browseItems = [
+    {
+      itemId: "hc-token-filter",
+      title: "Scotty Cameron Newport 2 Headcover",
+      price: { value: "150", currency: "USD" },
+      itemWebUrl: "https://example.com/headcover",
+      seller: { username: "cover-seller" },
+      image: { imageUrl: "https://example.com/headcover.jpg" },
+      shippingOptions: [
+        { shippingCost: { value: "0", currency: "USD" } },
+      ],
+      buyingOptions: ["FIXED_PRICE"],
+      itemSpecifics: [],
+      localizedAspects: [],
+      additionalProductIdentities: [],
+      returnTerms: {},
+      itemLocation: {},
+    },
+  ];
+
+  global.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input?.toString();
+    if (!url) throw new Error("Missing URL in fetch stub");
+
+    if (url.includes("/identity/")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ access_token: "fake-token", expires_in: 7200 }),
+        text: async () => "",
+      };
+    }
+
+    if (url.startsWith("https://api.ebay.com/buy/browse/v1/item_summary/search")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ itemSummaries: browseItems, total: browseItems.length }),
+        text: async () => "",
+      };
+    }
+
+    throw new Error(`Unexpected fetch URL: ${url}`);
+  };
+
+  const req = {
+    method: "GET",
+    query: {
+      q: "Scotty Cameron Newport 2 35in RH headcover",
+      group: "false",
+      forceCategory: "false",
+    },
+    headers: { host: "test.local", "user-agent": "node" },
+  };
+  const res = createMockRes();
+
+  try {
+    await handler(req, res);
+  } finally {
+    global.fetch = originalFetch;
+    process.env.EBAY_CLIENT_ID = originalClientId;
+    process.env.EBAY_CLIENT_SECRET = originalClientSecret;
+  }
+
+  assert.equal(res.statusCode, 200, "handler should respond with 200");
+  assert.ok(res.jsonBody, "response body should be captured");
+  assert.ok(Array.isArray(res.jsonBody.offers), "offers array should be present");
+  assert.equal(res.jsonBody.offers.length, 1, "headcover listing should remain despite missing spec tokens");
+  assert.equal(
+    res.jsonBody.offers[0]?.title,
+    "Scotty Cameron Newport 2 Headcover",
+    "headcover-only listing should survive when query includes length/dex tokens"
+  );
+});
+
 test("headcover-only listings survive strict putter filter when requested", async () => {
   const mod = await modulePromise;
   const handler = mod.default;


### PR DESCRIPTION
## Summary
- ignore dexterity and length-only tokens when building headcover query filters so accessory listings without spec metadata still match
- extend the headcover API test suite with a regression case covering queries that include RH/35in fragments

## Testing
- `node --test pages/api/__tests__/putters.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68dc423347248325bf4d24d3cc39eac5