### PR TITLE
Preserve decimal separators in sanitized search queries

### DIFF
--- a/lib/__tests__/buildDealCtaHref.test.js
+++ b/lib/__tests__/buildDealCtaHref.test.js
@@ -91,6 +91,29 @@ test("buildDealCtaHref prefers sanitized search phrase retaining brand tokens", 
   }
 });
 
+test("buildDealCtaHref retains decimal delimiters in sanitized queries", async () => {
+  const { buildDealCtaHref } = await modulePromise;
+
+  const deal = {
+    modelKey: "Titleist|Scotty Cameron|Studio Style|Newport 2.5",
+    label: "Scotty Cameron Studio Style Newport 2.5", 
+    query: "Scotty Cameron Studio Style Newport 2.5",
+    queryVariants: {
+      clean: "Scotty Cameron Studio Style Newport 2.5",
+      accessory: "Scotty Cameron Studio Style Newport 2.5 Headcover",
+    },
+    bestOffer: {
+      title: "Scotty Cameron Studio Style Newport 2.5 Putter",
+    },
+  };
+
+  const { query } = buildDealCtaHref(deal);
+
+  assert.ok(query.includes("2.5"), `expected query to retain decimal delimiter (saw: ${query})`);
+  assert.ok(!/\b2\s+5\b/.test(query), "expected digits around decimal to stay together");
+  assert.match(query, /\bputter\b/i, "expected sanitizeCandidate to append putter token");
+});
+
 test("buildDealCtaHref keeps headcover token for headcover-only deals", async () => {
   const { buildDealCtaHref } = await modulePromise;
 

--- a/lib/sanitizeModelKey.js
+++ b/lib/sanitizeModelKey.js
@@ -263,13 +263,17 @@ export function stripAccessoryTokens(text = "", options = {}) {
   return tokens.join(" ");
 }
 
+const DECIMAL_MARK_PLACEHOLDER = "DECIMALMARK";
+
 function removeEmojiAndPunctuation(text = "") {
   if (!text) return "";
   return String(text)
     .normalize("NFKD")
     .replace(/[\u0300-\u036f]/gu, "")
     .replace(/\p{Extended_Pictographic}/gu, " ")
+    .replace(/(?<=\d)[.,](?=\d)/g, DECIMAL_MARK_PLACEHOLDER)
     .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(new RegExp(DECIMAL_MARK_PLACEHOLDER, "g"), ".")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/pages/api/__tests__/putters.test.js
+++ b/pages/api/__tests__/putters.test.js
@@ -377,6 +377,16 @@ test("handler eBay calls retain putter for standard putter searches", async () =
   );
 });
 
+test("handler passes decimal search terms through to eBay", async () => {
+  const search = "Scotty Cameron Studio Style Newport 2.5";
+  const browseUrls = await collectBrowseQueriesFor(search);
+  assert.ok(browseUrls.length > 0, "decimal query should trigger eBay browse calls");
+  for (const url of browseUrls) {
+    const qParam = url.searchParams.get("q") || "";
+    assert.ok(qParam.includes("2.5"), `expected decimal to persist in browse URL (saw: ${qParam})`);
+  }
+});
+
 test("fetchEbayBrowse forwards supported sort options", async () => {
   const { fetchEbayBrowse } = await modulePromise;
 


### PR DESCRIPTION
## Summary
- preserve decimal delimiters when sanitizing model keys so numeric tokens stay intact
- add a buildDealCtaHref regression covering “Scotty Cameron Studio Style Newport 2.5”
- assert the putter API forwards decimal search terms unchanged to eBay

## Testing
- `node --test` *(fails: ERR_MODULE_NOT_FOUND for pages/api/db-test.js, pre-existing)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4550a82483258e15573054b073ad