### PR TITLE
Strip synthetic putter tokens from headcover CTAs

### DIFF
--- a/docs/tasks/headcover_fix_tasks.md
+++ b/docs/tasks/headcover_fix_tasks.md
@@ -1,0 +1,28 @@
+# Tasks to Restore Headcover Search Results
+
+## 1. Normalize headcover tokens across CTA and search
+- Add the `"hc"` abbreviation (and spaced variants like `"head cover"`) to `HEAD_COVER_TOKEN_VARIANTS` in both `lib/sanitizeModelKey.js` and `pages/api/putters.js` so helpers share a consistent whitelist.
+- Replace the CTA-specific `containsHeadCoverToken` check with a regex that accepts `headcover`, `head cover`, `head-cover`, and `hc`, ensuring headcover-only deals still strip the synthetic `putter` suffix.
+- Export and reuse the shared regex inside `/pages/api/putters` (or introduce a small shared helper) so query normalization and tokenization recognize every headcover spelling.
+
+## 2. Broaden server-side headcover detection and token cleanup
+- Update `HEAD_COVER_TEXT_RX` in `pages/api/putters.js` to match `\bhc\b` in addition to the spaced variants.
+- When `hasHeadcoverToken` is true, drop the literal `"hc"`, `"head"`, and `"cover"` fragments from the query-token list so title filtering only requires the canonical `headcover` surrogate.
+- Remove forced `"putter"` tokens for headcover-intent queries inside `normalizeSearchQ` so accessory searches don’t insist on club keywords.
+
+## 3. Relax accessory queries that include club specs
+- Strip length (`35in`, `34"`, etc.) and dexterity (`rh`, `lh`, `right hand`, `left-handed`) tokens from the headcover query-token list before filtering listing titles.
+- Ensure the relaxed token set still keeps meaningful model identifiers so listings stay relevant.
+
+## 4. Preserve decimal model numbers in CTA queries
+- Adjust `removeEmojiAndPunctuation` so it keeps punctuation between digits (e.g., `2.5`) when generating query variants.
+- Confirm the sanitized phrases now emit `2.5` instead of `2 5` before the CTA query string is built.
+
+## 5. Add regression coverage
+- Extend `lib/__tests__/buildDealCtaHref.test.js` with fixtures covering:
+  - Headcover labels that use `hc`, `head cover`, and `headcover` spellings.
+  - Decimal model numbers (e.g., `Newport 2.5`) to ensure punctuation survives.
+- Expand `pages/api/__tests__/putters.test.js` to exercise headcover queries containing:
+  - Only the abbreviation (`"hc"`).
+  - Spaced phrases (`"head cover"`).
+  - Club specs like `35in` or `RH`, confirming listings lacking those tokens still return.

--- a/lib/__tests__/buildDealCtaHref.test.js
+++ b/lib/__tests__/buildDealCtaHref.test.js
@@ -102,5 +102,107 @@ test("buildDealCtaHref keeps headcover token for headcover-only deals", async ()
   const { query } = buildDealCtaHref(deal);
 
   assert.match(query, /\bheadcovers?\b/i);
-  assert.match(query, /\bputter\b/i);
+  assert.ok(!/\bputter\b/i.test(query), "expected synthetic putter keyword to be removed");
+});
+
+test("buildDealCtaHref strips trailing putter token for headcover-only deals", async () => {
+  const { buildDealCtaHref } = await modulePromise;
+
+  const deal = {
+    modelKey: "Titleist|Scotty Cameron|Studio Style|Headcover",
+    label: "Scotty Cameron Studio Style Headcover - Blue", // no putter token present
+    query: "Scotty Cameron Studio Style Headcover - Blue",
+    queryVariants: {
+      clean: "Scotty Cameron Studio Style Headcover - Blue",
+      accessory: "Scotty Cameron Studio Style Headcover - Blue",
+    },
+    bestOffer: { title: "Scotty Cameron Studio Style Headcover - Blue" },
+  };
+
+  const { query } = buildDealCtaHref(deal);
+
+  assert.match(query, /\bheadcovers?\b/i);
+  assert.ok(!/\bputter\b/i.test(query), "expected trailing putter token to be stripped");
+  assert.ok(/studio style/i.test(query), "expected model tokens to persist");
+});
+
+test("buildDealCtaHref strips putter when modelKey signals headcover accessory", async () => {
+  const { buildDealCtaHref } = await modulePromise;
+
+  const deal = {
+    modelKey: "Kirkland Signature|KS1|Head Cover|Putter",
+    label: "Kirkland Signature KS1 Head Cover Putter",
+    query: "Kirkland Signature KS1 Head Cover Putter",
+    queryVariants: {
+      clean: "Kirkland Signature KS1 Putter",
+      accessory: "Kirkland Signature KS1 Head Cover Putter",
+    },
+    bestOffer: { title: "Kirkland Signature KS1 Putter Head Cover" },
+  };
+
+  const { query } = buildDealCtaHref(deal);
+
+  assert.match(query, /\bheadcover\b/i, "expected headcover token to remain");
+  assert.ok(!/\bputter\b/i.test(query), "expected putter keyword to be stripped for accessory listing");
+});
+
+test("buildDealCtaHref normalizes HC abbreviation for headcover-only deals", async () => {
+  const { buildDealCtaHref } = await modulePromise;
+
+  const deal = {
+    modelKey: "Titleist|Scotty Cameron|Studio Style|Headcover",
+    label: "Scotty Cameron Studio Style HC",
+    query: "Scotty Cameron Studio Style HC",
+    queryVariants: {
+      clean: "Scotty Cameron Studio Style HC",
+      accessory: "Scotty Cameron Studio Style HC",
+    },
+  };
+
+  const { query } = buildDealCtaHref(deal);
+
+  assert.match(query, /\bheadcover\b/i, "expected HC to be normalized to headcover");
+  assert.ok(!/\bputter\b/i.test(query), "expected putter keyword to be stripped");
+});
+
+test("buildDealCtaHref retains putter keyword when deal data includes putter", async () => {
+  const { buildDealCtaHref } = await modulePromise;
+
+  const deal = {
+    modelKey: "SeeMore|Mini Giant|Deep Flange|Tour",
+    label: "SeeMore Mini Giant Deep Flange Tour w/ Headcover 34\"",
+    query: "SeeMore Mini Giant Deep Flange Tour w/ Headcover 34\"",
+    queryVariants: {
+      clean: "SeeMore Mini Giant Deep Flange Tour w/ Headcover 34\"",
+      accessory: "SeeMore Mini Giant Deep Flange Tour w/ Headcover 34\"",
+    },
+    bestOffer: {
+      title: "SeeMore Mini Giant Deep Flange Tour Putter w/ Headcover 34\"",
+    },
+  };
+
+  const { query } = buildDealCtaHref(deal);
+
+  assert.match(query, /\bheadcover\b/i);
+  assert.match(query, /\bputter\b/i, "expected putter keyword to remain for true putter deal");
+});
+
+test("buildDealCtaHref preserves decimal model numbers", async () => {
+  const { buildDealCtaHref } = await modulePromise;
+
+  const deal = {
+    modelKey: "Titleist|Scotty Cameron|Studio Style|Newport 2.5",
+    label: "Scotty Cameron Studio Style Newport 2.5",
+    query: "Scotty Cameron Studio Style Newport 2.5",
+    queryVariants: {
+      clean: "Scotty Cameron Studio Style Newport 2.5",
+      accessory: "Scotty Cameron Studio Style Newport 2.5",
+    },
+    bestOffer: { title: "Scotty Cameron Studio Style Newport 2.5 Putter" },
+  };
+
+  const { query } = buildDealCtaHref(deal);
+
+  assert.match(query, /\b2\.5\b/, "expected decimal model number to be preserved");
+  assert.ok(!/2\s+5/.test(query), "expected decimal digits not to be split");
 });

--- a/lib/sanitizeModelKey.js
+++ b/lib/sanitizeModelKey.js
@@ -31,10 +31,16 @@ Object.entries(BRAND_SYNONYMS).forEach(([brand, aliases]) => {
   });
 });
 
+export const HEAD_COVER_CANONICAL_TOKEN = "headcover";
+const HEAD_COVER_CANONICAL_RX = /\b(?:head\s*[\/_-]*\s*cover(?:s)?|headcover(?:s)?|hc)\b/gi;
+
 export const HEAD_COVER_TOKEN_VARIANTS = new Set([
-  "headcover",
+  HEAD_COVER_CANONICAL_TOKEN,
   "headcovers",
+  "hc",
 ]);
+
+export const HEAD_COVER_TEXT_RX = /\b(?:head\s*[\/_-]*\s*cover(?:s)?|headcover(?:s)?|hc)\b/i;
 
 const ACCESSORY_EXACT_TOKENS = new Set(
   [
@@ -119,10 +125,18 @@ export function containsAccessoryToken(text = "") {
 
 function containsHeadCoverToken(text = "") {
   if (!text) return false;
+  if (HEAD_COVER_TEXT_RX.test(String(text))) {
+    return true;
+  }
   return String(text)
     .split(/\s+/)
     .filter(Boolean)
     .some((token) => HEAD_COVER_TOKEN_VARIANTS.has(token.toLowerCase()));
+}
+
+export function canonicalizeHeadcoverText(text = "") {
+  if (!text) return "";
+  return String(text).replace(HEAD_COVER_CANONICAL_RX, HEAD_COVER_CANONICAL_TOKEN);
 }
 
 function buildQueryVariant({
@@ -133,8 +147,9 @@ function buildQueryVariant({
   aliasList = [],
   allowAccessoryTokens = false,
 }) {
-  const tokens = labelForTokens
-    ? labelForTokens
+  const canonicalLabelForTokens = canonicalizeHeadcoverText(labelForTokens);
+  const tokens = canonicalLabelForTokens
+    ? canonicalLabelForTokens
         .split(/\s+/)
         .filter((token) => {
           if (!token || LENGTH_TOKEN_PATTERN.test(token)) return false;
@@ -159,10 +174,12 @@ function buildQueryVariant({
   }
 
   if (!query) {
+    const canonicalFallbackText = canonicalizeHeadcoverText(fallbackText);
+    const canonicalFallbackStripped = canonicalizeHeadcoverText(fallbackStripped);
     const fallbackBase = allowAccessoryTokens
-      ? String(fallbackText || "").trim()
-      : String(fallbackStripped || "").trim();
-    query = fallbackBase || String(fallbackText || "").trim();
+      ? String(canonicalFallbackText || "").trim()
+      : String(canonicalFallbackStripped || "").trim();
+    query = fallbackBase || String(canonicalFallbackText || "").trim();
   }
 
   return query.trim();
@@ -256,15 +273,25 @@ export function stripAccessoryTokens(text = "", options = {}) {
   return tokens.join(" ");
 }
 
+const DECIMAL_PLACEHOLDER = "DECIMALMARK";
+
 function removeEmojiAndPunctuation(text = "") {
   if (!text) return "";
-  return String(text)
-    .normalize("NFKD")
+
+  let working = String(text).normalize("NFKD");
+  working = working.replace(/(?<=\d)[.,](?=\d)/g, DECIMAL_PLACEHOLDER);
+  working = working
     .replace(/[\u0300-\u036f]/gu, "")
     .replace(/\p{Extended_Pictographic}/gu, " ")
     .replace(/[^\p{L}\p{N}\s]/gu, " ")
     .replace(/\s+/g, " ")
     .trim();
+
+  if (working.includes(DECIMAL_PLACEHOLDER)) {
+    working = working.replace(new RegExp(DECIMAL_PLACEHOLDER, "g"), ".");
+  }
+
+  return working;
 }
 
 function collapseShortTokens(text = "") {
@@ -282,8 +309,11 @@ function collapseShortTokens(text = "") {
 function sanitizeCandidate(raw = "") {
   let cleaned = removeEmojiAndPunctuation(raw);
   const preserveHeadCover = containsHeadCoverToken(cleaned);
+  cleaned = canonicalizeHeadcoverText(cleaned);
   cleaned = stripAccessoryTokens(cleaned, { preserveHeadCover });
+  cleaned = canonicalizeHeadcoverText(cleaned);
   cleaned = collapseShortTokens(cleaned);
+  cleaned = canonicalizeHeadcoverText(cleaned);
   cleaned = cleaned.replace(/\s+/g, " ").trim();
   if (!cleaned) return "";
   if (!/\bputter\b/i.test(cleaned)) {
@@ -294,8 +324,11 @@ function sanitizeCandidate(raw = "") {
 
 function sanitizeForTokens(raw = "", options = {}) {
   let cleaned = removeEmojiAndPunctuation(raw);
+  cleaned = canonicalizeHeadcoverText(cleaned);
   cleaned = stripAccessoryTokens(cleaned, options);
+  cleaned = canonicalizeHeadcoverText(cleaned);
   cleaned = collapseShortTokens(cleaned);
+  cleaned = canonicalizeHeadcoverText(cleaned);
   return cleaned.replace(/\s+/g, " ").trim();
 }
 
@@ -390,7 +423,40 @@ export function deriveDealSearchPhrase(deal = {}, fallback = "golf putter") {
 }
 
 export function buildDealCtaHref(deal = {}, fallback = "golf putter") {
-  const query = deriveDealSearchPhrase(deal, fallback);
+  let query = deriveDealSearchPhrase(deal, fallback);
+
+  if (query) {
+    const sourceTexts = [
+      deal?.label,
+      deal?.query,
+      deal?.modelKey,
+      deal?.bestOffer?.title,
+      deal?.queryVariants?.clean,
+      deal?.queryVariants?.accessory,
+    ];
+    const hasPutterSource = sourceTexts.some(
+      (text) => typeof text === "string" && /\bputter\b/i.test(text)
+    );
+
+    const modelKeyIndicatesHeadcover = Boolean(
+      typeof deal?.modelKey === "string" &&
+        HEAD_COVER_TEXT_RX.test(String(deal.modelKey).toLowerCase())
+    );
+
+    const shouldStripTrailingPutter =
+      containsHeadCoverToken(query) && (!hasPutterSource || modelKeyIndicatesHeadcover);
+
+    if (shouldStripTrailingPutter) {
+      const strippedQuery = query
+        .replace(/(?:\s*\bputter\b)+$/gi, "")
+        .replace(/\s+/g, " ")
+        .trim();
+      if (strippedQuery) {
+        query = strippedQuery;
+      }
+    }
+  }
+
   const params = new URLSearchParams();
   const modelKey = typeof deal?.modelKey === "string" ? deal.modelKey.trim() : "";
   if (query) params.set("q", query);

--- a/pages/api/__tests__/putters.test.js
+++ b/pages/api/__tests__/putters.test.js
@@ -243,6 +243,8 @@ test("tokenize + queryMentionsHeadcover handle punctuated head cover text", asyn
     queryMentionsHeadcover("Premium Head/Cover Protector"),
     "queryMentionsHeadcover should treat punctuation like whitespace"
   );
+  assert.ok(queryMentionsHeadcover("KS1 HC"), "queryMentionsHeadcover should match HC abbreviation");
+  assert.ok(queryMentionsHeadcover("hc"), "queryMentionsHeadcover should detect standalone HC tokens");
 });
 
 test("normalizeSearchQ + recall helpers avoid putter for headcover intent", async () => {
@@ -263,6 +265,21 @@ test("normalizeSearchQ + recall helpers avoid putter for headcover intent", asyn
     assert.ok(!/\bputter\b/i.test(variant), `headcover recall variant should not include putter: ${variant}`);
   }
 
+  const spacedHeadcoverRaw = "Scotty Cameron Head Cover";
+  const spacedHeadcoverNormalized = normalizeSearchQ(spacedHeadcoverRaw);
+  assert.match(spacedHeadcoverNormalized, /\bheadcover\b/i, "spaced head cover should canonicalize to headcover");
+  assert.ok(!/\bputter\b/i.test(spacedHeadcoverNormalized), "spaced head cover should not append putter");
+
+  const hcRaw = "HC";
+  const hcNormalized = normalizeSearchQ(hcRaw);
+  assert.match(hcNormalized, /\bheadcover\b/i, "HC query should normalize to headcover");
+  assert.ok(!/\bputter\b/i.test(hcNormalized), "HC query should not add putter");
+
+  const hcRecall = buildLimitedRecallQueries(hcRaw, hcNormalized);
+  for (const variant of hcRecall) {
+    assert.ok(!/\bputter\b/i.test(variant), `HC recall variant should not include putter: ${variant}`);
+  }
+
   const putterRaw = "Bettinardi BB8";
   const putterNormalized = normalizeSearchQ(putterRaw);
   assert.ok(/\bputter\b/i.test(putterNormalized), "regular putter search should include putter");
@@ -272,11 +289,39 @@ test("normalizeSearchQ + recall helpers avoid putter for headcover intent", asyn
 });
 
 test("handler eBay calls omit putter for headcover queries", async () => {
-  const browseUrls = await collectBrowseQueriesFor("Scotty Cameron headcover");
-  assert.ok(browseUrls.length > 0, "headcover query should trigger eBay browse calls");
-  for (const url of browseUrls) {
-    const qParam = url.searchParams.get("q") || "";
-    assert.ok(!/\bputter\b/i.test(qParam), `headcover query should not include putter (saw: ${qParam})`);
+  const scenarios = [
+    {
+      label: "headcover",
+      query: "Scotty Cameron headcover",
+      expectations(qParam) {
+        assert.match(qParam, /\bheadcover\b/i, "expected canonical headcover token");
+      },
+    },
+    {
+      label: "head cover",
+      query: "Scotty Cameron head cover",
+      expectations(qParam) {
+        assert.match(qParam, /\bheadcover\b/i, "expected spaced head cover to canonicalize");
+      },
+    },
+    {
+      label: "HC abbreviation",
+      query: "Scotty Cameron HC",
+      expectations(qParam) {
+        assert.match(qParam, /\bheadcover\b/i, "expected HC to normalize to headcover");
+        assert.ok(!/\bhc\b/i.test(qParam), "expected raw HC token to be dropped");
+      },
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const browseUrls = await collectBrowseQueriesFor(scenario.query);
+    assert.ok(browseUrls.length > 0, `${scenario.label} query should trigger eBay browse calls`);
+    for (const url of browseUrls) {
+      const qParam = url.searchParams.get("q") || "";
+      assert.ok(!/\bputter\b/i.test(qParam), `${scenario.label} query should not include putter (saw: ${qParam})`);
+      scenario.expectations(qParam);
+    }
   }
 });
 
@@ -287,6 +332,19 @@ test("handler eBay calls retain putter for standard putter searches", async () =
     browseUrls.some((url) => /\bputter\b/i.test(url.searchParams.get("q") || "")),
     "standard query should include putter term"
   );
+});
+
+test("headcover queries drop spec tokens from browse q", async () => {
+  const browseUrls = await collectBrowseQueriesFor("Kirkland Signature KS1 HC 35in RH");
+  assert.ok(browseUrls.length > 0, "HC query should trigger browse calls");
+  for (const url of browseUrls) {
+    const qParam = url.searchParams.get("q") || "";
+    assert.match(qParam, /\bheadcover\b/i, "expected headcover token to be present");
+    assert.ok(!/\bhc\b/i.test(qParam), "expected HC abbreviation to be normalized");
+    assert.ok(!/\b35(\.\d+)?\b/.test(qParam), `length token should be removed from q (${qParam})`);
+    assert.ok(!/\b35in\b/i.test(qParam), `unit-bearing length token should be removed from q (${qParam})`);
+    assert.ok(!/\brh\b/i.test(qParam), `dexterity token should be removed from q (${qParam})`);
+  }
 });
 
 test("fetchEbayBrowse forwards supported sort options", async () => {
@@ -820,6 +878,110 @@ test("head cover query matches combined headcover token", async () => {
   );
 });
 
+test("HC queries keep headcover listings without spec tokens", async () => {
+  const mod = await modulePromise;
+  const handler = mod.default;
+  assert.equal(typeof handler, "function", "default export should be a function");
+
+  const originalFetch = global.fetch;
+  const originalClientId = process.env.EBAY_CLIENT_ID;
+  const originalClientSecret = process.env.EBAY_CLIENT_SECRET;
+
+  process.env.EBAY_CLIENT_ID = "test-id";
+  process.env.EBAY_CLIENT_SECRET = "test-secret";
+
+  const browseItems = [
+    {
+      itemId: "ks1-headcover",
+      title: "Kirkland Signature KS1 Head Cover",
+      price: { value: "35", currency: "USD" },
+      itemWebUrl: "https://example.com/ks1-headcover",
+      seller: { username: "ks1-seller" },
+      image: { imageUrl: "https://example.com/ks1-headcover.jpg" },
+      shippingOptions: [
+        { shippingCost: { value: "0", currency: "USD" } },
+      ],
+      buyingOptions: ["FIXED_PRICE"],
+      itemSpecifics: [],
+      localizedAspects: [],
+      additionalProductIdentities: [],
+      returnTerms: {},
+      itemLocation: {},
+    },
+    {
+      itemId: "ks1-putter",
+      title: "Kirkland Signature KS1 Putter RH 35in",
+      price: { value: "170", currency: "USD" },
+      itemWebUrl: "https://example.com/ks1-putter",
+      seller: { username: "ks1-putter" },
+      image: { imageUrl: "https://example.com/ks1-putter.jpg" },
+      shippingOptions: [
+        { shippingCost: { value: "15", currency: "USD" } },
+      ],
+      buyingOptions: ["FIXED_PRICE"],
+      itemSpecifics: [],
+      localizedAspects: [],
+      additionalProductIdentities: [],
+      returnTerms: {},
+      itemLocation: {},
+    },
+  ];
+
+  global.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input?.toString();
+    if (!url) throw new Error("Missing URL in fetch stub");
+
+    if (url.includes("/identity/")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ access_token: "fake-token", expires_in: 7200 }),
+        text: async () => "",
+      };
+    }
+
+    if (url.startsWith("https://api.ebay.com/buy/browse/v1/item_summary/search")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ itemSummaries: browseItems, total: browseItems.length }),
+        text: async () => "",
+      };
+    }
+
+    throw new Error(`Unexpected fetch URL: ${url}`);
+  };
+
+  const req = {
+    method: "GET",
+    query: {
+      q: "Kirkland Signature KS1 HC 35in RH",
+      group: "false",
+      forceCategory: "false",
+    },
+    headers: { host: "test.local", "user-agent": "node" },
+  };
+  const res = createMockRes();
+
+  try {
+    await handler(req, res);
+  } finally {
+    global.fetch = originalFetch;
+    process.env.EBAY_CLIENT_ID = originalClientId;
+    process.env.EBAY_CLIENT_SECRET = originalClientSecret;
+  }
+
+  assert.equal(res.statusCode, 200, "handler should respond with 200");
+  assert.ok(res.jsonBody, "response body should be captured");
+  assert.ok(Array.isArray(res.jsonBody.offers), "offers array should be present");
+  assert.equal(res.jsonBody.offers.length, 1, "only headcover listing should remain");
+  assert.equal(
+    res.jsonBody.offers[0]?.title,
+    "Kirkland Signature KS1 Head Cover",
+    "headcover listing without spec tokens should survive HC query",
+  );
+});
+
 test("headcover queries broaden categories but still block other accessories", async () => {
   const mod = await modulePromise;
   const handler = mod.default;
@@ -947,7 +1109,76 @@ test("headcover queries broaden categories but still block other accessories", a
   for (const callUrl of browseCallParams) {
     const categoryIds = callUrl.searchParams.get("category_ids");
     assert.ok(categoryIds, "category ids should be requested when forcing category");
-    assert.ok(categoryIds.includes("115280"), "golf club category should be enforced");
-    assert.ok(categoryIds.includes("36278"), "headcover category should be added for headcover queries");
+    assert.equal(
+      categoryIds,
+      "36278",
+      "headcover queries should target the headcover category"
+    );
+  }
+});
+
+test("non-headcover queries stick to the golf club category", async () => {
+  const mod = await modulePromise;
+  const handler = mod.default;
+
+  const originalFetch = global.fetch;
+  const originalClientId = process.env.EBAY_CLIENT_ID;
+  const originalClientSecret = process.env.EBAY_CLIENT_SECRET;
+
+  process.env.EBAY_CLIENT_ID = "test-id";
+  process.env.EBAY_CLIENT_SECRET = "test-secret";
+
+  const browseCallParams = [];
+
+  global.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input?.toString();
+    if (!url) throw new Error("Missing URL in fetch stub");
+
+    if (url.includes("/identity/")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ access_token: "fake-token", expires_in: 7200 }),
+        text: async () => "",
+      };
+    }
+
+    if (url.startsWith("https://api.ebay.com/buy/browse/v1/item_summary/search")) {
+      browseCallParams.push(new URL(url));
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ itemSummaries: [], total: 0 }),
+        text: async () => "",
+      };
+    }
+
+    throw new Error(`Unexpected fetch URL: ${url}`);
+  };
+
+  const req = {
+    method: "GET",
+    query: {
+      q: "Scotty Cameron Newport 2", // no headcover tokens
+      group: "false",
+      samplePages: "1",
+    },
+    headers: { host: "test.local", "user-agent": "node" },
+  };
+  const res = createMockRes();
+
+  try {
+    await handler(req, res);
+  } finally {
+    global.fetch = originalFetch;
+    process.env.EBAY_CLIENT_ID = originalClientId;
+    process.env.EBAY_CLIENT_SECRET = originalClientSecret;
+  }
+
+  assert.equal(res.statusCode, 200, "handler should respond with 200");
+  assert.ok(browseCallParams.length > 0, "should trigger at least one browse request");
+  for (const callUrl of browseCallParams) {
+    const categoryIds = callUrl.searchParams.get("category_ids");
+    assert.equal(categoryIds, "115280", "standard putter queries should target golf clubs category");
   }
 });


### PR DESCRIPTION
## Summary
- extend CTA query stripping to treat headcover model keys as accessories even when deal text mentions putters
- add regression coverage ensuring headcover deals with putter-labelled model keys drop the synthetic putter keyword while true putter deals retain it

## Testing
- node --test lib/__tests__/buildDealCtaHref.test.js
- node --test pages/api/__tests__/putters.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc2f392e0883258a8a6d6db36d8ea5