### PR TITLE
Guard CTA headcover detection when trimming queries

### DIFF
--- a/lib/sanitizeModelKey.js
+++ b/lib/sanitizeModelKey.js
@@ -415,7 +415,16 @@ export function buildDealCtaHref(deal = {}, fallback = "golf putter") {
     const hasPutterSource = sourceTexts.some(
       (text) => typeof text === "string" && /\bputter\b/i.test(text)
     );
-    if (!hasPutterSource && containsHeadCoverToken(query)) {
+    const modelKeyFlagsHeadcover = containsHeadCoverToken(deal?.modelKey);
+    const accessoryVariantSignalsHeadcover = containsHeadCoverToken(
+      deal?.queryVariants?.accessory
+    );
+    const shouldStripSyntheticPutter =
+      !hasPutterSource &&
+      containsHeadCoverToken(query) &&
+      (modelKeyFlagsHeadcover || accessoryVariantSignalsHeadcover);
+
+    if (shouldStripSyntheticPutter) {
       const strippedQuery = query
         .replace(/(?:\s*\bputter\b)+$/gi, "")
         .replace(/\s+/g, " ")


### PR DESCRIPTION
## Summary
- tighten buildDealCtaHref to only strip synthetic putter tokens when the query and model key indicate a headcover accessory

## Testing
- node --test lib/__tests__/buildDealCtaHref.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc58cb21ac832588bfbc88554c5559