### PR TITLE
Normalize headcover query sanitization across CTA and browse

### DIFF
--- a/lib/__tests__/buildDealCtaHref.test.js
+++ b/lib/__tests__/buildDealCtaHref.test.js
@@ -194,3 +194,23 @@ test("buildDealCtaHref drops synthetic putter for HC-only phrasing", async () =>
   assert.ok(/\bhc\b/i.test(query), "expected HC abbreviation to remain in query");
   assert.ok(!/\bputter\b/i.test(query), "expected synthetic putter keyword to be removed for HC-only phrase");
 });
+
+test("buildDealCtaHref drops length and dexterity tokens from headcover queries", async () => {
+  const { buildDealCtaHref } = await modulePromise;
+
+  const deal = {
+    modelKey: "Titleist|Scotty Cameron|Newport 2|Headcover",
+    label: "Scotty Cameron Newport 2 35in RH headcover", 
+    query: "Scotty Cameron Newport 2 35in RH headcover",
+    queryVariants: {
+      clean: "Scotty Cameron Newport 2 35in RH headcover",
+      accessory: "Scotty Cameron Newport 2 35in RH headcover",
+    },
+  };
+
+  const { query } = buildDealCtaHref(deal);
+
+  assert.match(query, HEAD_COVER_REGEX, "expected headcover token to persist");
+  assert.ok(!/\b35(?:in|inch|inches)?\b/i.test(query), "expected length tokens to be removed");
+  assert.ok(!/\brh\b/i.test(query), "expected dexterity tokens to be removed");
+});

--- a/lib/sanitizeModelKey.js
+++ b/lib/sanitizeModelKey.js
@@ -1,3 +1,5 @@
+import { detectDexterity, extractLengthInches } from "./specs-parse.js";
+
 const BRAND_PATTERNS = [
   { key: "Scotty Cameron", pattern: /scotty\s+cameron/i },
   { key: "TaylorMade", pattern: /taylormade|tm\b/i },
@@ -39,6 +41,28 @@ export const HEAD_COVER_TOKEN_VARIANTS = new Set([
 
 export const HEAD_COVER_TEXT_RX =
   /\bhead(?:[\s/_-]*?)cover(s)?\b|\bheadcover(s)?\b|\bhc\b/i;
+
+export const HEAD_COVER_SPEC_DROP_TOKENS = new Set([
+  "lh",
+  "rh",
+  "left",
+  "right",
+  "lefty",
+  "righty",
+  "lefthand",
+  "righthand",
+  "lefthanded",
+  "righthanded",
+  "hand",
+  "handed",
+  "in",
+  "inch",
+  "inches",
+]);
+
+export const HEAD_COVER_LENGTH_TOKEN_RX = /^3[3-6](?:\.\d+)?$/;
+export const HEAD_COVER_LENGTH_SUFFIX_RX = /^3[3-6](?:in|inch|inches|"|”|“)?$/;
+const DEX_SUFFIX_RX = /(lh|rh)$/i;
 
 const ACCESSORY_EXACT_TOKENS = new Set(
   [
@@ -131,6 +155,84 @@ function containsHeadCoverToken(text = "") {
     .split(/\s+/)
     .filter(Boolean)
     .some((token) => HEAD_COVER_TOKEN_VARIANTS.has(token.toLowerCase()));
+}
+
+export function normalizeHeadcoverToken(token = "") {
+  return String(token || "").trim().toLowerCase();
+}
+
+function isDexterityTokenForHeadcover(token = "") {
+  const normalized = normalizeHeadcoverToken(token);
+  if (!normalized) return false;
+  if (HEAD_COVER_TOKEN_VARIANTS.has(normalized)) return false;
+  if (HEAD_COVER_SPEC_DROP_TOKENS.has(normalized)) return true;
+  if (/^(?:lh|rh)[0-9]+$/.test(normalized)) return true;
+  if (/^[0-9]+(?:lh|rh)$/.test(normalized)) return true;
+  if (detectDexterity(normalized)) return true;
+  if (detectDexterity(`${normalized} hand`)) return true;
+  return false;
+}
+
+function isLengthTokenForHeadcover(token = "") {
+  const normalized = normalizeHeadcoverToken(token).replace(/[“”]/g, '"');
+  if (!normalized) return false;
+  if (HEAD_COVER_TOKEN_VARIANTS.has(normalized)) return false;
+
+  if (HEAD_COVER_LENGTH_TOKEN_RX.test(normalized)) {
+    const numeric = Number(normalized);
+    if (Number.isFinite(numeric) && numeric >= 30 && numeric <= 40) return true;
+    if (/\d/.test(normalized)) return true;
+  }
+
+  if (HEAD_COVER_LENGTH_SUFFIX_RX.test(normalized)) {
+    return true;
+  }
+
+  const normalizedForExtract = normalized.replace(/inches$/, "inch");
+  const lengthVal = extractLengthInches(normalizedForExtract);
+  return Number.isFinite(lengthVal);
+}
+
+export function shouldDropHeadcoverSpecToken(token = "") {
+  const normalized = normalizeHeadcoverToken(token);
+  if (!normalized) return false;
+  if (HEAD_COVER_TOKEN_VARIANTS.has(normalized)) return false;
+
+  if (isDexterityTokenForHeadcover(normalized) || isLengthTokenForHeadcover(normalized)) {
+    return true;
+  }
+
+  const suffixMatch = normalized.match(DEX_SUFFIX_RX);
+  if (suffixMatch) {
+    const base = normalized.slice(0, -suffixMatch[0].length);
+    if (isLengthTokenForHeadcover(base) || isDexterityTokenForHeadcover(base)) {
+      return true;
+    }
+  }
+
+  const prefixMatch = normalized.match(/^(lh|rh)/);
+  if (prefixMatch) {
+    const base = normalized.slice(prefixMatch[0].length);
+    if (isLengthTokenForHeadcover(base)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function stripHeadcoverSpecTokens(tokens = []) {
+  if (!Array.isArray(tokens) || tokens.length === 0) return [];
+  return tokens.filter((token) => !shouldDropHeadcoverSpecToken(token));
+}
+
+function stripHeadcoverSpecTokensFromString(text = "") {
+  if (!text) return "";
+  const tokens = String(text)
+    .split(/\s+/)
+    .filter(Boolean);
+  const filtered = stripHeadcoverSpecTokens(tokens);
+  return filtered.join(" ");
 }
 
 function buildQueryVariant({
@@ -295,6 +397,9 @@ function sanitizeCandidate(raw = "") {
   let cleaned = removeEmojiAndPunctuation(raw);
   const preserveHeadCover = containsHeadCoverToken(cleaned);
   cleaned = stripAccessoryTokens(cleaned, { preserveHeadCover });
+  if (preserveHeadCover) {
+    cleaned = stripHeadcoverSpecTokensFromString(cleaned);
+  }
   cleaned = collapseShortTokens(cleaned);
   cleaned = cleaned.replace(/\s+/g, " ").trim();
   if (!cleaned) return "";
@@ -307,6 +412,9 @@ function sanitizeCandidate(raw = "") {
 function sanitizeForTokens(raw = "", options = {}) {
   let cleaned = removeEmojiAndPunctuation(raw);
   cleaned = stripAccessoryTokens(cleaned, options);
+  if (options?.preserveHeadCover) {
+    cleaned = stripHeadcoverSpecTokensFromString(cleaned);
+  }
   cleaned = collapseShortTokens(cleaned);
   return cleaned.replace(/\s+/g, " ").trim();
 }

--- a/pages/api/putters.js
+++ b/pages/api/putters.js
@@ -1,12 +1,15 @@
 /* eslint-disable no-console */
 
 import { decorateEbayUrl } from "../../lib/affiliate.js";
-import { detectDexterity, extractLengthInches } from "../../lib/specs-parse.js";
+import { detectDexterity } from "../../lib/specs-parse.js";
 import {
   containsAccessoryToken,
   stripAccessoryTokens,
   HEAD_COVER_TOKEN_VARIANTS,
   HEAD_COVER_TEXT_RX,
+  normalizeHeadcoverToken,
+  shouldDropHeadcoverSpecToken,
+  stripHeadcoverSpecTokens,
 } from "../../lib/sanitizeModelKey.js";
 
 /**
@@ -31,28 +34,6 @@ const EBAY_SITE = process.env.EBAY_SITE || "EBAY_US";
 const CATEGORY_GOLF_CLUBS = "115280";
 const CATEGORY_PUTTER_HEADCOVERS = "36278";
 const ACCESSORY_BLOCK_PATTERN = /\b(shafts?|grips?|weights?)\b/i;
-const HEAD_COVER_SPEC_DROP_TOKENS = new Set([
-  "lh",
-  "rh",
-  "left",
-  "right",
-  "lefty",
-  "righty",
-  "lefthand",
-  "righthand",
-  "lefthanded",
-  "righthanded",
-  "hand",
-  "handed",
-  "in",
-  "inch",
-  "inches",
-]);
-
-const HEAD_COVER_LENGTH_TOKEN_RX = /^3[3-6](?:\.\d+)?$/;
-const HEAD_COVER_LENGTH_SUFFIX_RX = /^3[3-6](?:in|inch|inches|"|”|“)?$/;
-const DEX_SUFFIX_RX = /(lh|rh)$/i;
-
 // -------------------- Token --------------------
 let _tok = { val: null, exp: 0 };
 
@@ -148,73 +129,6 @@ const tokenize = (s) => {
 
   return Array.from(tokenSet);
 };
-
-const normalizeHeadcoverToken = (token) => String(token || "").trim().toLowerCase();
-
-function isDexterityTokenForHeadcover(token) {
-  const normalized = normalizeHeadcoverToken(token);
-  if (!normalized) return false;
-  if (HEAD_COVER_TOKEN_VARIANTS.has(normalized)) return false;
-  if (HEAD_COVER_SPEC_DROP_TOKENS.has(normalized)) return true;
-  if (/^(?:lh|rh)[0-9]+$/.test(normalized)) return true;
-  if (/^[0-9]+(?:lh|rh)$/.test(normalized)) return true;
-  if (detectDexterity(normalized)) return true;
-  if (detectDexterity(`${normalized} hand`)) return true;
-  return false;
-}
-
-function isLengthTokenForHeadcover(token) {
-  const normalized = normalizeHeadcoverToken(token).replace(/[“”]/g, '"');
-  if (!normalized) return false;
-  if (HEAD_COVER_TOKEN_VARIANTS.has(normalized)) return false;
-
-  if (HEAD_COVER_LENGTH_TOKEN_RX.test(normalized)) {
-    const numeric = Number(normalized);
-    if (Number.isFinite(numeric) && numeric >= 30 && numeric <= 40) return true;
-    if (/\d/.test(normalized)) return true;
-  }
-
-  if (HEAD_COVER_LENGTH_SUFFIX_RX.test(normalized)) {
-    return true;
-  }
-
-  const normalizedForExtract = normalized.replace(/inches$/, "inch");
-  const lengthVal = extractLengthInches(normalizedForExtract);
-  return Number.isFinite(lengthVal);
-}
-
-function shouldDropHeadcoverSpecToken(token) {
-  const normalized = normalizeHeadcoverToken(token);
-  if (!normalized) return false;
-  if (HEAD_COVER_TOKEN_VARIANTS.has(normalized)) return false;
-
-  if (isDexterityTokenForHeadcover(normalized) || isLengthTokenForHeadcover(normalized)) {
-    return true;
-  }
-
-  const suffixMatch = normalized.match(DEX_SUFFIX_RX);
-  if (suffixMatch) {
-    const base = normalized.slice(0, -suffixMatch[0].length);
-    if (isLengthTokenForHeadcover(base) || isDexterityTokenForHeadcover(base)) {
-      return true;
-    }
-  }
-
-  const prefixMatch = normalized.match(/^(lh|rh)/);
-  if (prefixMatch) {
-    const base = normalized.slice(prefixMatch[0].length);
-    if (isLengthTokenForHeadcover(base)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-function stripHeadcoverSpecTokens(tokens = []) {
-  if (!Array.isArray(tokens) || tokens.length === 0) return [];
-  return tokens.filter((token) => !shouldDropHeadcoverSpecToken(token));
-}
 
 function pickCheapestShipping(shippingOptions) {
   if (!Array.isArray(shippingOptions) || shippingOptions.length === 0) return null;


### PR DESCRIPTION
## Summary
- share headcover token normalization logic so browse filters and CTA builders use the same helpers
- strip dexterity and length markers from headcover CTA queries while keeping the headcover keyword
- extend the CTA unit tests to cover removal of RH and 35in tokens

## Testing
- node --test lib/__tests__/buildDealCtaHref.test.js
- node --test pages/api/__tests__/putters.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dc5e4c7314832587b89c630719e90b