### PR TITLE
Relax headcover matching for headcover searches

### DIFF
--- a/pages/api/__tests__/putters.test.js
+++ b/pages/api/__tests__/putters.test.js
@@ -1113,6 +1113,110 @@ test("headcover query tolerates missing non-essential tokens", async () => {
   );
 });
 
+test("headcover query requires headcover token but allows partial non-headcover matches", async () => {
+  const mod = await modulePromise;
+  const handler = mod.default;
+  assert.equal(typeof handler, "function", "default export should be a function");
+
+  const originalFetch = global.fetch;
+  const originalClientId = process.env.EBAY_CLIENT_ID;
+  const originalClientSecret = process.env.EBAY_CLIENT_SECRET;
+
+  process.env.EBAY_CLIENT_ID = "test-id";
+  process.env.EBAY_CLIENT_SECRET = "test-secret";
+
+  const browseItems = [
+    {
+      itemId: "phantom-headcover",
+      title: "Scotty Cameron Phantom X Headcover",
+      price: { value: "180", currency: "USD" },
+      itemWebUrl: "https://example.com/phantom-headcover",
+      seller: { username: "phantom-seller" },
+      image: { imageUrl: "https://example.com/phantom-headcover.jpg" },
+      shippingOptions: [
+        { shippingCost: { value: "0", currency: "USD" } },
+      ],
+      buyingOptions: ["FIXED_PRICE"],
+      itemSpecifics: [],
+      localizedAspects: [],
+      additionalProductIdentities: [],
+      returnTerms: {},
+      itemLocation: {},
+    },
+    {
+      itemId: "phantom-putter",
+      title: "Scotty Cameron Phantom X 5.5 Putter",
+      price: { value: "450", currency: "USD" },
+      itemWebUrl: "https://example.com/phantom-putter",
+      seller: { username: "putter-seller" },
+      image: { imageUrl: "https://example.com/phantom-putter.jpg" },
+      shippingOptions: [
+        { shippingCost: { value: "20", currency: "USD" } },
+      ],
+      buyingOptions: ["FIXED_PRICE"],
+      itemSpecifics: [],
+      localizedAspects: [],
+      additionalProductIdentities: [],
+      returnTerms: {},
+      itemLocation: {},
+    },
+  ];
+
+  global.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input?.toString();
+    if (!url) throw new Error("Missing URL in fetch stub");
+
+    if (url.includes("/identity/")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ access_token: "fake-token", expires_in: 7200 }),
+        text: async () => "",
+      };
+    }
+
+    if (url.startsWith("https://api.ebay.com/buy/browse/v1/item_summary/search")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ itemSummaries: browseItems, total: browseItems.length }),
+        text: async () => "",
+      };
+    }
+
+    throw new Error(`Unexpected fetch URL: ${url}`);
+  };
+
+  const req = {
+    method: "GET",
+    query: {
+      q: "Scotty Cameron Phantom X 5.5 Circle T headcover",
+      group: "false",
+      forceCategory: "false",
+    },
+    headers: { host: "test.local", "user-agent": "node" },
+  };
+  const res = createMockRes();
+
+  try {
+    await handler(req, res);
+  } finally {
+    global.fetch = originalFetch;
+    process.env.EBAY_CLIENT_ID = originalClientId;
+    process.env.EBAY_CLIENT_SECRET = originalClientSecret;
+  }
+
+  assert.equal(res.statusCode, 200, "handler should respond with 200");
+  assert.ok(res.jsonBody, "response body should be captured");
+  assert.ok(Array.isArray(res.jsonBody.offers), "offers array should be present");
+  assert.equal(res.jsonBody.offers.length, 1, "only headcover listing should remain");
+  assert.equal(
+    res.jsonBody.offers[0]?.title,
+    "Scotty Cameron Phantom X Headcover",
+    "headcover listing should remain even when some non-headcover tokens are missing"
+  );
+});
+
 test("headcover queries broaden categories but still block other accessories", async () => {
   const mod = await modulePromise;
   const handler = mod.default;

--- a/pages/api/putters.js
+++ b/pages/api/putters.js
@@ -1024,15 +1024,19 @@ export default async function handler(req, res) {
           return queryTokens.every((tok) => matchesToken(tok));
         }
 
-        const headcoverTokens = queryTokens.filter((tok) => HEAD_COVER_TOKEN_VARIANTS.has(tok));
+        let headcoverMatch = false;
+        for (const variant of HEAD_COVER_TOKEN_VARIANTS) {
+          if (matchesToken(variant)) {
+            headcoverMatch = true;
+            break;
+          }
+        }
+
+        if (!headcoverMatch) {
+          return false;
+        }
+
         const nonHeadcoverTokens = queryTokens.filter((tok) => !HEAD_COVER_TOKEN_VARIANTS.has(tok));
-
-        const hasHeadcoverMatch =
-          headcoverTokens.length === 0
-            ? true
-            : headcoverTokens.some((tok) => matchesToken(tok));
-        if (!hasHeadcoverMatch) return false;
-
         if (!nonHeadcoverTokens.length) {
           return true;
         }


### PR DESCRIPTION
## Summary
- ensure headcover searches require listings to include at least one headcover token variant
- relax headcover searches to allow partial matches on non-headcover tokens
- add unit coverage for headcover queries missing some non-headcover tokens

## Testing
- node --test pages/api/__tests__/putters.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dca0f75904832592922e2eda4b16f1