### PR TITLE
Preserve Jet Set phrasing in deal sanitization

### DIFF
--- a/lib/__tests__/buildDealCtaHref.test.js
+++ b/lib/__tests__/buildDealCtaHref.test.js
@@ -43,6 +43,57 @@ test("buildDealCtaHref removes noisy tokens and preserves modelKey", async () =>
   assert.equal(url.searchParams.get("q"), query);
 });
 
+test("buildDealCtaHref preserves Jet Set phrase in sanitized outputs", async () => {
+  const { sanitizeModelKey, deriveDealSearchPhrase, buildDealCtaHref } =
+    await modulePromise;
+
+  const rawKey = "Titleist|Scotty Cameron|Special Select Jet Set|Newport 2";
+  const sanitized = sanitizeModelKey(rawKey);
+
+  assert.match(
+    sanitized.label,
+    /\bjet set\b/i,
+    "expected sanitizeModelKey label to retain Jet Set tokens"
+  );
+  assert.match(
+    sanitized.query,
+    /\bjet set\b/i,
+    "expected sanitizeModelKey query to retain Jet Set tokens"
+  );
+
+  const deal = {
+    modelKey: rawKey,
+    label: "Scotty Cameron Special Select Jet Set Newport 2 34\" Putter",
+    query: "Scotty Cameron Special Select Jet Set Newport 2 34\" Putter",
+    queryVariants: {
+      clean: "Scotty Cameron Special Select Jet Set Newport 2 34\" Putter",
+      accessory:
+        "Scotty Cameron Special Select Jet Set Newport 2 34\" Putter",
+    },
+    bestOffer: {
+      title: "Scotty Cameron Special Select Jet Set Newport 2 Putter",
+    },
+  };
+
+  const derivedPhrase = deriveDealSearchPhrase(deal);
+  assert.match(
+    derivedPhrase,
+    /\bjet set\b/i,
+    "expected deriveDealSearchPhrase to retain Jet Set tokens"
+  );
+
+  const { query, href } = buildDealCtaHref(deal);
+  assert.match(query, /\bjet set\b/i, "expected CTA query to retain Jet Set tokens");
+
+  const url = new URL(href, "https://example.com");
+  assert.equal(url.searchParams.get("q"), query);
+  assert.match(
+    url.searchParams.get("q") || "",
+    /\bjet set\b/i,
+    "expected CTA URL to include Jet Set tokens"
+  );
+});
+
 test("buildDealCtaHref prefers sanitized search phrase retaining brand tokens", async () => {
   const { buildDealCtaHref } = await modulePromise;
 

--- a/lib/sanitizeModelKey.js
+++ b/lib/sanitizeModelKey.js
@@ -104,6 +104,48 @@ const ACCESSORY_TOKEN_PATTERNS = [
 
 const LENGTH_TOKEN_PATTERN = /^\d+(?:\.\d+)?(?:(?:in)|["”])?$/i;
 
+const PROTECTED_ACCESSORY_PHRASES = [
+  ["jet", "set"],
+];
+
+function normalizeAccessoryFilterToken(token = "") {
+  return String(token || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+}
+
+function getProtectedAccessoryTokenIndices(tokens = []) {
+  if (!Array.isArray(tokens) || tokens.length === 0) {
+    return new Set();
+  }
+
+  const normalizedTokens = tokens.map((token) => normalizeAccessoryFilterToken(token));
+  const protectedIndices = new Set();
+
+  PROTECTED_ACCESSORY_PHRASES.forEach((phrase) => {
+    const normalizedPhrase = phrase.map((part) => normalizeAccessoryFilterToken(part));
+    if (!normalizedPhrase.length || normalizedPhrase.some((part) => !part)) {
+      return;
+    }
+    for (let index = 0; index <= normalizedTokens.length - normalizedPhrase.length; index += 1) {
+      let matches = true;
+      for (let offset = 0; offset < normalizedPhrase.length; offset += 1) {
+        if (normalizedTokens[index + offset] !== normalizedPhrase[offset]) {
+          matches = false;
+          break;
+        }
+      }
+      if (matches) {
+        for (let offset = 0; offset < normalizedPhrase.length; offset += 1) {
+          protectedIndices.add(index + offset);
+        }
+      }
+    }
+  });
+
+  return protectedIndices;
+}
+
 const DESCRIPTOR_TOKENS = new Set([
   "mint",
   "brand",
@@ -243,17 +285,23 @@ function buildQueryVariant({
   aliasList = [],
   allowAccessoryTokens = false,
 }) {
-  const tokens = labelForTokens
+  const rawTokens = labelForTokens
     ? labelForTokens
         .split(/\s+/)
-        .filter((token) => {
-          if (!token || LENGTH_TOKEN_PATTERN.test(token)) return false;
-          const normalized = token.toLowerCase();
-          if (DESCRIPTOR_TOKENS.has(normalized)) return false;
-          if (!allowAccessoryTokens && isAccessoryToken(token)) return false;
-          return true;
-        })
+        .filter(Boolean)
     : [];
+
+  const protectedIndices = getProtectedAccessoryTokenIndices(rawTokens);
+
+  const tokens = rawTokens.filter((token, index) => {
+    if (!token || LENGTH_TOKEN_PATTERN.test(token)) return false;
+    const normalized = token.toLowerCase();
+    if (DESCRIPTOR_TOKENS.has(normalized)) return false;
+    if (!allowAccessoryTokens && !protectedIndices.has(index) && isAccessoryToken(token)) {
+      return false;
+    }
+    return true;
+  });
 
   const searchText = tokens.join(" ").trim();
 
@@ -356,14 +404,20 @@ export function stripAccessoryTokens(text = "", options = {}) {
   if (!text) return "";
   const tokens = String(text)
     .split(/\s+/)
-    .filter(Boolean)
-    .filter((token) => {
-      if (preserveHeadCover && HEAD_COVER_TOKEN_VARIANTS.has(token.toLowerCase())) {
-        return true;
-      }
-      return !isAccessoryToken(token);
-    });
-  return tokens.join(" ");
+    .filter(Boolean);
+
+  const protectedIndices = getProtectedAccessoryTokenIndices(tokens);
+
+  const filtered = tokens.filter((token, index) => {
+    if (preserveHeadCover && HEAD_COVER_TOKEN_VARIANTS.has(token.toLowerCase())) {
+      return true;
+    }
+    if (protectedIndices.has(index)) {
+      return true;
+    }
+    return !isAccessoryToken(token);
+  });
+  return filtered.join(" ");
 }
 
 const DECIMAL_MARK_PLACEHOLDER = "DECIMALMARK";


### PR DESCRIPTION
## Summary
- add protection for Jet Set tokens when stripping accessory words and when building queries
- ensure Jet Set phrasing flows through sanitizeCandidate, deriveDealSearchPhrase, and buildDealCtaHref
- add a regression test that verifies Jet Set deals keep the phrase in the CTA query

## Testing
- node --test lib/__tests__/buildDealCtaHref.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dcadd27c108325859f469ce0f3d0ee