### PR TITLE
Allow headcover queries to bypass forced eBay categories

### DIFF
--- a/pages/api/putters.js
+++ b/pages/api/putters.js
@@ -823,15 +823,14 @@ async function fetchEbayBrowse({
   };
   const ebaySort = sortMap[normalizedSort];
   if (ebaySort) url.searchParams.set("sort", ebaySort);
-  if (forceCategory) {
+  const headcoverIntent = queryMentionsHeadcover(q);
+  if (forceCategory && !headcoverIntent) {
     const categoryIds = new Set([CATEGORY_GOLF_CLUBS]);
-    if (queryMentionsHeadcover(q)) {
-      for (const headcoverCategory of CATEGORY_ALL_HEADCOVERS) {
-        if (headcoverCategory) categoryIds.add(headcoverCategory);
-      }
-    }
     url.searchParams.set("category_ids", Array.from(categoryIds).join(","));
   }
+  // Headcover-specific searches intentionally skip the category filter so that
+  // eBay's dedicated headcover categories (including the general "Golf Club
+  // Headcovers" bucket) remain eligible.
 
   const filterParts = [];
   if (Array.isArray(buyingOptions) && buyingOptions.length) {


### PR DESCRIPTION
## Summary
- skip forcing the golf-club category filter on eBay Browse when the query targets headcovers so general headcover listings are eligible
- add regression coverage to ensure headcover searches omit the forced category and keep results from the newly allowed bucket

## Testing
- node --test pages/api/__tests__/putters.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dcb216c988832592fd8bc857dc4e25