### PR TITLE
Ensure Jet Set tokens survive accessory stripping

### DIFF
--- a/lib/__tests__/buildDealCtaHref.test.js
+++ b/lib/__tests__/buildDealCtaHref.test.js
@@ -8,6 +8,21 @@ const moduleHref = pathToFileURL(modulePath).href;
 const modulePromise = import(moduleHref);
 
 const HEAD_COVER_REGEX = /\bhead(?:\s|-)?covers?\b/i;
+const normalizeJetSetCheck = (value) =>
+  String(value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+
+function hasJetSetTokens(value) {
+  if (!value) {
+    return false;
+  }
+  if (/\bjet\s+set\b/i.test(String(value))) {
+    return true;
+  }
+  const normalized = normalizeJetSetCheck(value);
+  return normalized.includes("jetset");
+}
 
 test("buildDealCtaHref removes noisy tokens and preserves modelKey", async () => {
   const { buildDealCtaHref } = await modulePromise;
@@ -92,6 +107,57 @@ test("buildDealCtaHref preserves Jet Set phrase in sanitized outputs", async () 
     /\bjet set\b/i,
     "expected CTA URL to include Jet Set tokens"
   );
+});
+
+test("buildDealCtaHref keeps Jet Set tokens across formatting variants", async () => {
+  const { sanitizeModelKey, buildDealCtaHref } = await modulePromise;
+
+  const variants = [
+    {
+      labelSegment: "Special Select JetSet",
+      dealLabel: "Scotty Cameron Special Select JetSet Newport 2 34\" Putter",
+      description: "JetSet",
+    },
+    {
+      labelSegment: "Special Select Jet-Set",
+      dealLabel: "Scotty Cameron Special Select Jet-Set Newport 2 34\" Putter",
+      description: "Jet-Set",
+    },
+    {
+      labelSegment: "Special Select Jet Set™",
+      dealLabel: "Scotty Cameron Special Select Jet Set™ Newport 2 34\" Putter",
+      description: "Jet Set™",
+    },
+  ];
+
+  for (const variant of variants) {
+    const rawKey = `Titleist|Scotty Cameron|${variant.labelSegment}|Newport 2`;
+    const sanitized = sanitizeModelKey(rawKey);
+
+    assert.ok(
+      hasJetSetTokens(sanitized.label),
+      `expected sanitizeModelKey label to retain Jet Set tokens for ${variant.description}`
+    );
+
+    const deal = {
+      modelKey: rawKey,
+      label: variant.dealLabel,
+      query: variant.dealLabel,
+      queryVariants: {
+        clean: variant.dealLabel,
+        accessory: variant.dealLabel,
+      },
+      bestOffer: {
+        title: variant.dealLabel,
+      },
+    };
+
+    const { query } = buildDealCtaHref(deal);
+    assert.ok(
+      hasJetSetTokens(query),
+      `expected CTA query to retain Jet Set tokens for ${variant.description}`
+    );
+  }
 });
 
 test("buildDealCtaHref prefers sanitized search phrase retaining brand tokens", async () => {

--- a/lib/sanitizeModelKey.js
+++ b/lib/sanitizeModelKey.js
@@ -108,6 +108,8 @@ const PROTECTED_ACCESSORY_PHRASES = [
   ["jet", "set"],
 ];
 
+const PROTECTED_ACCESSORY_SUBSTRINGS = ["jetset"];
+
 function normalizeAccessoryFilterToken(token = "") {
   return String(token || "")
     .toLowerCase()
@@ -144,6 +146,21 @@ function getProtectedAccessoryTokenIndices(tokens = []) {
   });
 
   return protectedIndices;
+}
+
+function isProtectedAccessoryToken(token = "") {
+  if (!token) {
+    return false;
+  }
+
+  const normalized = normalizeAccessoryFilterToken(token);
+  if (!normalized) {
+    return false;
+  }
+
+  return PROTECTED_ACCESSORY_SUBSTRINGS.some((substring) =>
+    normalized.includes(substring)
+  );
 }
 
 const DESCRIPTOR_TOKENS = new Set([
@@ -297,7 +314,12 @@ function buildQueryVariant({
     if (!token || LENGTH_TOKEN_PATTERN.test(token)) return false;
     const normalized = token.toLowerCase();
     if (DESCRIPTOR_TOKENS.has(normalized)) return false;
-    if (!allowAccessoryTokens && !protectedIndices.has(index) && isAccessoryToken(token)) {
+    if (
+      !allowAccessoryTokens &&
+      !protectedIndices.has(index) &&
+      !isProtectedAccessoryToken(token) &&
+      isAccessoryToken(token)
+    ) {
       return false;
     }
     return true;
@@ -410,6 +432,9 @@ export function stripAccessoryTokens(text = "", options = {}) {
 
   const filtered = tokens.filter((token, index) => {
     if (preserveHeadCover && HEAD_COVER_TOKEN_VARIANTS.has(token.toLowerCase())) {
+      return true;
+    }
+    if (isProtectedAccessoryToken(token)) {
       return true;
     }
     if (protectedIndices.has(index)) {


### PR DESCRIPTION
## Summary
- add substring-based protection to the accessory token stripper so Jet Set is never downgraded
- apply the same guard in query construction paths that filter accessory tokens
- cover Jet Set formatting variants (JetSet, Jet-Set, Jet Set™) in the CTA tests

## Testing
- node --test lib/__tests__/buildDealCtaHref.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dcb9a86a608325b24b4c232fddeb19