### PR TITLE
Guard limited edition model phrases from accessory stripping

### DIFF
--- a/lib/__tests__/buildDealCtaHref.test.js
+++ b/lib/__tests__/buildDealCtaHref.test.js
@@ -160,6 +160,93 @@ test("buildDealCtaHref keeps Jet Set tokens across formatting variants", async (
   }
 });
 
+test("buildDealCtaHref guards limited release phrases without protecting real accessory kits", async () => {
+  const { sanitizeModelKey, buildDealCtaHref } = await modulePromise;
+
+  const guardScenarios = [
+    {
+      description: "Jet Set release",
+      rawKey: "Titleist|Scotty Cameron|Special Select Jet Set|Newport 2",
+      deal: {
+        modelKey: "Titleist|Scotty Cameron|Special Select Jet Set|Newport 2",
+        label: "Scotty Cameron Special Select Jet Set Newport 2 Circle T Tool Putter",
+        query: "Scotty Cameron Special Select Jet Set Newport 2 Circle T Tool Putter",
+        queryVariants: {
+          clean: "Scotty Cameron Special Select Jet Set Newport 2 Circle T Tool Putter",
+          accessory: "Scotty Cameron Special Select Jet Set Newport 2 Circle T Tool Putter",
+        },
+        bestOffer: {
+          title: "Scotty Cameron Special Select Jet Set Newport 2 Circle T Tool Putter",
+        },
+      },
+      expected: /\bjet\s*set\b/i,
+      extraAssertions: ({ query }) => {
+        assert.match(
+          query,
+          /\btool\b/i,
+          "expected Circle T Tool phrasing to preserve the tool token"
+        );
+      },
+    },
+    {
+      description: "Bettinardi Tour Kit release",
+      rawKey: "Bettinardi|Tour Dept|Tour Kit",
+      deal: {
+        modelKey: "Bettinardi|Tour Dept|Tour Kit",
+        label: "Bettinardi Tour Kit DASS Hive 34\" Putter",
+        query: "Bettinardi Tour Kit DASS Hive 34\" Putter",
+        queryVariants: {
+          clean: "Bettinardi Tour Kit DASS Hive 34\" Putter",
+          accessory: "Bettinardi Tour Kit DASS Hive 34\" Putter",
+        },
+        bestOffer: {
+          title: "Bettinardi Tour Kit DASS Hive 34\" Putter",
+        },
+      },
+      expected: /\btour kit\b/i,
+    },
+  ];
+
+  for (const scenario of guardScenarios) {
+    const sanitized = sanitizeModelKey(scenario.rawKey);
+    assert.match(
+      sanitized.label,
+      scenario.expected,
+      `expected sanitizeModelKey label to retain ${scenario.description}`
+    );
+
+    const { query } = buildDealCtaHref(scenario.deal);
+    assert.match(
+      query,
+      scenario.expected,
+      `expected CTA query to retain ${scenario.description}`
+    );
+    if (typeof scenario.extraAssertions === "function") {
+      scenario.extraAssertions({ query, sanitized });
+    }
+  }
+
+  const accessoryDeal = {
+    modelKey: "TaylorMade|Spider|Weight Kit",
+    label: "TaylorMade Spider Weight Kit",
+    query: "TaylorMade Spider Weight Kit",
+    queryVariants: {
+      clean: "TaylorMade Spider Weight Kit",
+      accessory: "TaylorMade Spider Weight Kit",
+    },
+    bestOffer: {
+      title: "TaylorMade Spider Weight Kit",
+    },
+  };
+
+  const { query: accessoryQuery } = buildDealCtaHref(accessoryDeal);
+  assert.doesNotMatch(
+    accessoryQuery,
+    /\bkit\b/i,
+    "expected accessory kit tokens to be stripped from generic bundles"
+  );
+});
+
 test("buildDealCtaHref prefers sanitized search phrase retaining brand tokens", async () => {
   const { buildDealCtaHref } = await modulePromise;
 

--- a/lib/config/brandLimitedTokens.js
+++ b/lib/config/brandLimitedTokens.js
@@ -1,0 +1,76 @@
+export const BRAND_LIMITED_TOKENS = {
+  // Scotty Cameron
+  "scotty cameron": [
+    "circle t",
+    "tour rat",
+    "009",
+    "009m",
+    "009h",
+    "009s",
+    "gss",
+    "my girl",
+    "button back",
+    "oil can",
+    "pro platinum",
+    "newport beach",
+    "napa",
+    "napa valley",
+    "studio design",
+    "tei3",
+    "tel3",
+  ],
+  // Bettinardi
+  bettinardi: [
+    "hive",
+    "tour stock",
+    "dass",
+    "bb0",
+    "bb8",
+    "bb8 flow",
+    "bb8f",
+    "tiki",
+    "stinger",
+    "damascus",
+    "limited run",
+    "tour dept",
+  ],
+  // TaylorMade
+  taylormade: [
+    "spider limited",
+    "spider tour",
+    "itsy bitsy",
+    "tour issue",
+    "tour only",
+  ],
+  // Odyssey / Toulon
+  odyssey: [
+    "tour issue",
+    "tour only",
+    "prototype",
+    "japan limited",
+    "ten limited",
+    "eleven limited",
+  ],
+  toulon: ["garage", "small batch", "tour issue", "tour only"],
+  // PING
+  ping: [
+    "pld limited",
+    "pld milled limited",
+    "scottsdale tr",
+    "anser becu",
+    "anser copper",
+    "vault",
+  ],
+  // L.A.B. Golf
+  "l.a.b.": ["limited", "tour issue", "tour only", "df3 limited", "mezz limited"],
+  "lab golf": ["limited", "tour issue", "tour only", "df3 limited", "mezz limited"],
+  // Evnroll
+  evnroll: ["tour proto", "tour preferred", "v-series tourspec", "limited"],
+  // Mizuno
+  mizuno: ["m-craft limited", "m craft limited", "copper", "japan limited"],
+  // Wilson
+  wilson: ["8802 limited", "8802 copper", "tour issue"],
+  // SIK / others
+  sik: ["tour issue", "limited", "prototype"],
+};
+

--- a/lib/sanitizeModelKey.js
+++ b/lib/sanitizeModelKey.js
@@ -1,4 +1,5 @@
 import { detectDexterity, extractLengthInches } from "./specs-parse.js";
+import { BRAND_LIMITED_TOKENS } from "./config/brandLimitedTokens.js";
 
 const BRAND_PATTERNS = [
   { key: "Scotty Cameron", pattern: /scotty\s+cameron/i },
@@ -104,11 +105,163 @@ const ACCESSORY_TOKEN_PATTERNS = [
 
 const LENGTH_TOKEN_PATTERN = /^\d+(?:\.\d+)?(?:(?:in)|["”])?$/i;
 
-const PROTECTED_ACCESSORY_PHRASES = [
-  ["jet", "set"],
-];
+const MODEL_PHRASE_GUARDS = {
+  global: [["jet", "set"]],
+  brands: {
+    bettinardi: [["tour", "kit"]],
+    "scotty cameron": [["circle", "t", "tool"], ["circle", "t", "tools"]],
+  },
+};
 
-const PROTECTED_ACCESSORY_SUBSTRINGS = ["jetset"];
+const ACCESSORY_GUARD_SUFFIX_TOKENS = new Set([
+  "kit",
+  "kits",
+  "set",
+  "sets",
+  "tool",
+  "tools",
+]);
+
+const MODEL_PHRASE_PROTECTED_SUBSTRINGS = new Set();
+
+const BRAND_LIMITED_TOKEN_METADATA = (() => {
+  const map = new Map();
+  const concatLookup = new Map();
+
+  Object.entries(BRAND_LIMITED_TOKENS).forEach(([brandKey, phrases]) => {
+    if (!Array.isArray(phrases) || !phrases.length) return;
+
+    const normalizedBrand = String(brandKey || "").toLowerCase();
+    if (!normalizedBrand) return;
+
+    const normalizedPhrases = phrases
+      .map((phrase) =>
+        String(phrase || "")
+          .split(/[^a-z0-9]+/i)
+          .map((token) => normalizeAccessoryFilterToken(token))
+          .filter(Boolean)
+      )
+      .filter((tokens) => tokens.length);
+
+    if (!normalizedPhrases.length) return;
+
+    const concatenated = new Set();
+    normalizedPhrases.forEach((tokens) => {
+      if (tokens.length > 1) {
+        concatenated.add(tokens.join(""));
+      }
+    });
+
+    map.set(normalizedBrand, normalizedPhrases);
+    concatLookup.set(normalizedBrand, concatenated);
+  });
+
+  return { map, concatLookup };
+})();
+
+const BRAND_LIMITED_TOKEN_SEQUENCES = BRAND_LIMITED_TOKEN_METADATA.map;
+const BRAND_LIMITED_TOKEN_CONCAT_LOOKUP =
+  BRAND_LIMITED_TOKEN_METADATA.concatLookup;
+
+function addNormalizedGuardSequence(map, brandKey, normalizedTokens, seen) {
+  if (!Array.isArray(normalizedTokens) || !normalizedTokens.length) {
+    return;
+  }
+
+  const key = brandKey ? String(brandKey).toLowerCase() : null;
+  const signature = `${key || "*"}:${normalizedTokens.join("|")}`;
+  if (seen.has(signature)) {
+    return;
+  }
+  seen.add(signature);
+
+  if (normalizedTokens.length === 1) {
+    MODEL_PHRASE_PROTECTED_SUBSTRINGS.add(normalizedTokens[0]);
+  } else {
+    MODEL_PHRASE_PROTECTED_SUBSTRINGS.add(normalizedTokens.join(""));
+  }
+
+  const list = map.get(key);
+  if (list) {
+    list.push(normalizedTokens);
+  } else {
+    map.set(key, [normalizedTokens]);
+  }
+}
+
+function addGuardSequence(map, brandKey, phrase, seen) {
+  const tokens = Array.isArray(phrase)
+    ? phrase
+    : String(phrase || "")
+        .split(/\s+/)
+        .filter(Boolean);
+
+  const normalizedTokens = tokens
+    .map((token) => normalizeAccessoryFilterToken(token))
+    .filter(Boolean);
+
+  addNormalizedGuardSequence(map, brandKey, normalizedTokens, seen);
+
+  if (normalizedTokens.length > 1) {
+    const collapsed = normalizedTokens.join("");
+    if (collapsed) {
+      addNormalizedGuardSequence(map, brandKey, [collapsed], seen);
+    }
+  }
+}
+
+function buildModelPhraseAllowlist() {
+  const allowlist = new Map();
+  const seen = new Set();
+
+  if (Array.isArray(MODEL_PHRASE_GUARDS.global)) {
+    MODEL_PHRASE_GUARDS.global.forEach((phrase) => {
+      addGuardSequence(allowlist, null, phrase, seen);
+    });
+  }
+
+  if (MODEL_PHRASE_GUARDS.brands) {
+    Object.entries(MODEL_PHRASE_GUARDS.brands).forEach(
+      ([brandKey, phrases]) => {
+        if (!Array.isArray(phrases)) return;
+        phrases.forEach((phrase) => {
+          addGuardSequence(allowlist, brandKey, phrase, seen);
+        });
+      }
+    );
+  }
+
+  return allowlist;
+}
+
+const MODEL_PHRASE_ALLOWLIST = buildModelPhraseAllowlist();
+
+function normalizeBrandKey(brand = null) {
+  if (!brand) return null;
+  const normalized = String(brand || "").trim().toLowerCase();
+  if (!normalized) return null;
+  const aliasBrand = BRAND_ALIAS_LOOKUP.get(normalized);
+  return aliasBrand ? aliasBrand.toLowerCase() : normalized;
+}
+
+function collectAllowlistSequences(normalizedBrand = null) {
+  const sequences = [];
+  const pushSequences = (list) => {
+    if (!Array.isArray(list)) return;
+    list.forEach((sequence) => {
+      if (Array.isArray(sequence) && sequence.length) {
+        sequences.push(sequence);
+      }
+    });
+  };
+
+  pushSequences(MODEL_PHRASE_ALLOWLIST.get(null));
+  if (normalizedBrand) {
+    pushSequences(MODEL_PHRASE_ALLOWLIST.get(normalizedBrand));
+  }
+
+  return sequences;
+}
 
 function normalizeAccessoryFilterToken(token = "") {
   return String(token || "")
@@ -116,39 +269,114 @@ function normalizeAccessoryFilterToken(token = "") {
     .replace(/[^a-z0-9]+/g, "");
 }
 
-function getProtectedAccessoryTokenIndices(tokens = []) {
+function getProtectedAccessoryTokenIndices(tokens = [], options = {}) {
   if (!Array.isArray(tokens) || tokens.length === 0) {
     return new Set();
   }
 
-  const normalizedTokens = tokens.map((token) => normalizeAccessoryFilterToken(token));
+  const normalizedTokens = Array.isArray(options?.normalizedTokens)
+    ? options.normalizedTokens
+    : tokens.map((token) => normalizeAccessoryFilterToken(token));
+
+  const normalizedBrand = normalizeBrandKey(options?.brand);
   const protectedIndices = new Set();
 
-  PROTECTED_ACCESSORY_PHRASES.forEach((phrase) => {
-    const normalizedPhrase = phrase.map((part) => normalizeAccessoryFilterToken(part));
-    if (!normalizedPhrase.length || normalizedPhrase.some((part) => !part)) {
-      return;
-    }
-    for (let index = 0; index <= normalizedTokens.length - normalizedPhrase.length; index += 1) {
+  const allowlistSequences = collectAllowlistSequences(normalizedBrand);
+  allowlistSequences.forEach((sequence) => {
+    const length = sequence.length;
+    if (!length || length > normalizedTokens.length) return;
+    for (let index = 0; index <= normalizedTokens.length - length; index += 1) {
       let matches = true;
-      for (let offset = 0; offset < normalizedPhrase.length; offset += 1) {
-        if (normalizedTokens[index + offset] !== normalizedPhrase[offset]) {
+      for (let offset = 0; offset < length; offset += 1) {
+        if (normalizedTokens[index + offset] !== sequence[offset]) {
           matches = false;
           break;
         }
       }
       if (matches) {
-        for (let offset = 0; offset < normalizedPhrase.length; offset += 1) {
+        for (let offset = 0; offset < length; offset += 1) {
           protectedIndices.add(index + offset);
         }
       }
     }
   });
 
+  if (normalizedBrand) {
+    const limitedSequences =
+      BRAND_LIMITED_TOKEN_SEQUENCES.get(normalizedBrand) || [];
+    const limitedConcat =
+      BRAND_LIMITED_TOKEN_CONCAT_LOOKUP.get(normalizedBrand) || new Set();
+
+    for (let index = 0; index < normalizedTokens.length; index += 1) {
+      const token = normalizedTokens[index];
+      if (!ACCESSORY_GUARD_SUFFIX_TOKENS.has(token)) continue;
+
+      limitedSequences.forEach((sequence) => {
+        const length = sequence.length;
+        if (!length) return;
+
+        const start = index - length;
+        if (start >= 0) {
+          let matches = true;
+          for (let offset = 0; offset < length; offset += 1) {
+            if (normalizedTokens[start + offset] !== sequence[offset]) {
+              matches = false;
+              break;
+            }
+          }
+          if (matches) {
+            for (let offset = 0; offset < length; offset += 1) {
+              protectedIndices.add(start + offset);
+            }
+            protectedIndices.add(index);
+          }
+        }
+
+        if (
+          length > 1 &&
+          index > 0 &&
+          normalizedTokens[index - 1] &&
+          limitedConcat.has(normalizedTokens[index - 1])
+        ) {
+          protectedIndices.add(index - 1);
+          protectedIndices.add(index);
+        }
+      });
+    }
+  }
+
   return protectedIndices;
 }
 
-function isProtectedAccessoryToken(token = "") {
+function sequenceMatchesAtIndex(normalizedTokens = [], index = -1, sequence = []) {
+  if (!Array.isArray(sequence) || !sequence.length) return false;
+  if (!Array.isArray(normalizedTokens) || normalizedTokens.length === 0) {
+    return false;
+  }
+  if (index < 0 || index >= normalizedTokens.length) return false;
+
+  const token = normalizedTokens[index];
+  for (let position = 0; position < sequence.length; position += 1) {
+    if (sequence[position] !== token) continue;
+    const start = index - position;
+    if (start < 0 || start + sequence.length > normalizedTokens.length) {
+      continue;
+    }
+    let matches = true;
+    for (let offset = 0; offset < sequence.length; offset += 1) {
+      if (normalizedTokens[start + offset] !== sequence[offset]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isProtectedAccessoryToken(token = "", options = {}) {
   if (!token) {
     return false;
   }
@@ -158,9 +386,39 @@ function isProtectedAccessoryToken(token = "") {
     return false;
   }
 
-  return PROTECTED_ACCESSORY_SUBSTRINGS.some((substring) =>
-    normalized.includes(substring)
-  );
+  if (MODEL_PHRASE_PROTECTED_SUBSTRINGS.has(normalized)) {
+    return true;
+  }
+
+  const normalizedTokens = Array.isArray(options?.normalizedTokens)
+    ? options.normalizedTokens
+    : null;
+  const index = typeof options?.index === "number" ? options.index : -1;
+  const normalizedBrand = normalizeBrandKey(options?.brand);
+
+  if (normalizedTokens && index >= 0) {
+    const allowlistSequences = collectAllowlistSequences(normalizedBrand);
+    for (const sequence of allowlistSequences) {
+      if (sequenceMatchesAtIndex(normalizedTokens, index, sequence)) {
+        return true;
+      }
+    }
+  }
+
+  if (
+    normalizedBrand &&
+    normalizedTokens &&
+    index > 0 &&
+    ACCESSORY_GUARD_SUFFIX_TOKENS.has(normalized)
+  ) {
+    const limitedConcat =
+      BRAND_LIMITED_TOKEN_CONCAT_LOOKUP.get(normalizedBrand) || new Set();
+    if (limitedConcat.has(normalizedTokens[index - 1])) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 const DESCRIPTOR_TOKENS = new Set([
@@ -308,7 +566,20 @@ function buildQueryVariant({
         .filter(Boolean)
     : [];
 
-  const protectedIndices = getProtectedAccessoryTokenIndices(rawTokens);
+  const normalizedTokens = rawTokens.map((token) =>
+    normalizeAccessoryFilterToken(token)
+  );
+
+  const guardBrand = brandForQuery || aliasList?.[0] || null;
+  const guardContext = {
+    brand: guardBrand,
+    normalizedTokens,
+  };
+
+  const protectedIndices = getProtectedAccessoryTokenIndices(
+    rawTokens,
+    guardContext
+  );
 
   const tokens = rawTokens.filter((token, index) => {
     if (!token || LENGTH_TOKEN_PATTERN.test(token)) return false;
@@ -317,7 +588,10 @@ function buildQueryVariant({
     if (
       !allowAccessoryTokens &&
       !protectedIndices.has(index) &&
-      !isProtectedAccessoryToken(token) &&
+      !isProtectedAccessoryToken(token, {
+        ...guardContext,
+        index,
+      }) &&
       isAccessoryToken(token)
     ) {
       return false;
@@ -422,22 +696,37 @@ export function detectCanonicalBrand(rawKey = "") {
 }
 
 export function stripAccessoryTokens(text = "", options = {}) {
-  const { preserveHeadCover = false } = options || {};
+  const { preserveHeadCover = false, brand: providedBrand = null } = options || {};
   if (!text) return "";
   const tokens = String(text)
     .split(/\s+/)
     .filter(Boolean);
 
-  const protectedIndices = getProtectedAccessoryTokenIndices(tokens);
+  const normalizedTokens = tokens.map((token) =>
+    normalizeAccessoryFilterToken(token)
+  );
+
+  const detectedBrand = providedBrand || detectCanonicalBrand(tokens.join(" "));
+  const guardContext = {
+    brand: detectedBrand,
+    normalizedTokens,
+  };
+
+  const protectedIndices = getProtectedAccessoryTokenIndices(tokens, guardContext);
 
   const filtered = tokens.filter((token, index) => {
     if (preserveHeadCover && HEAD_COVER_TOKEN_VARIANTS.has(token.toLowerCase())) {
       return true;
     }
-    if (isProtectedAccessoryToken(token)) {
+    if (protectedIndices.has(index)) {
       return true;
     }
-    if (protectedIndices.has(index)) {
+    if (
+      isProtectedAccessoryToken(token, {
+        ...guardContext,
+        index,
+      })
+    ) {
       return true;
     }
     return !isAccessoryToken(token);
@@ -694,9 +983,13 @@ export function sanitizeModelKey(rawKey = "", options = {}) {
 
   const fallbackText = working || String(rawKey).trim();
   const normalizedFallback = String(fallbackText || "").trim();
-  const accessoryFreeFallback = stripAccessoryTokens(normalizedFallback).trim();
+  const accessoryFreeFallback = stripAccessoryTokens(normalizedFallback, {
+    brand: detectedBrand,
+  }).trim();
   const accessoryRichLabel = label.trim();
-  const accessoryFreeLabel = stripAccessoryTokens(accessoryRichLabel).trim();
+  const accessoryFreeLabel = stripAccessoryTokens(accessoryRichLabel, {
+    brand: detectedBrand,
+  }).trim();
   const cleanedLabel = accessoryFreeLabel;
   const fallbackLabel = accessoryFreeFallback || normalizedFallback;
   const humanLabel = cleanedLabel || fallbackLabel;

--- a/pages/api/putters.js
+++ b/pages/api/putters.js
@@ -11,6 +11,7 @@ import {
   shouldDropHeadcoverSpecToken,
   stripHeadcoverSpecTokens,
 } from "../../lib/sanitizeModelKey.js";
+import { BRAND_LIMITED_TOKENS } from "../../lib/config/brandLimitedTokens.js";
 
 /**
  * Required ENV (Vercel + .env.local):
@@ -604,46 +605,6 @@ const GLOBAL_LIMITED_TOKENS = [
   "japan only", "japan limited", "garage", "custom shop", "player issue",
   "beryllium", "becu", "copper", "dass", "damascus", "tiffany", "snow"
 ];
-
-const BRAND_LIMITED_TOKENS = {
-  // Scotty Cameron
-  "scotty cameron": [
-    "circle t", "tour rat", "009", "009m", "009h", "009s", "gss",
-    "my girl", "button back", "oil can", "pro platinum",
-    "newport beach", "napa", "napa valley", "studio design", "tei3", "tel3"
-  ],
-  // Bettinardi
-  "bettinardi": [
-    "hive", "tour stock", "dass", "bb0", "bb8", "bb8 flow", "bb8f",
-    "tiki", "stinger", "damascus", "limited run", "tour dept"
-  ],
-  // TaylorMade
-  "taylormade": [
-    "spider limited", "spider tour", "itsy bitsy", "tour issue", "tour only"
-  ],
-  // Odyssey / Toulon
-  "odyssey": [
-    "tour issue", "tour only", "prototype", "japan limited", "ten limited", "eleven limited"
-  ],
-  "toulon": [
-    "garage", "small batch", "tour issue", "tour only"
-  ],
-  // PING
-  "ping": [
-    "pld limited", "pld milled limited", "scottsdale tr", "anser becu", "anser copper", "vault"
-  ],
-  // L.A.B. Golf
-  "l.a.b.": ["limited", "tour issue", "tour only", "df3 limited", "mezz limited"],
-  "lab golf": ["limited", "tour issue", "tour only", "df3 limited", "mezz limited"],
-  // Evnroll
-  "evnroll": ["tour proto", "tour preferred", "v-series tourspec", "limited"],
-  // Mizuno
-  "mizuno": ["m-craft limited", "m craft limited", "copper", "japan limited"],
-  // Wilson
-  "wilson": ["8802 limited", "8802 copper", "tour issue"],
-  // SIK / others
-  "sik": ["tour issue", "limited", "prototype"],
-};
 
 const BRAND_ASSIST_ALIASES = [
   ...Object.keys(BRAND_LIMITED_TOKENS),


### PR DESCRIPTION
## Summary
- centralize brand limited token metadata so sanitization can share the same inputs as the API
- expand accessory token guards to respect limited release phrases and detected brand context while still dropping true accessory bundles
- add regression coverage for Jet Set and Bettinardi Tour Kit releases alongside an accessory kit baseline

## Testing
- node --test lib/__tests__/buildDealCtaHref.test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd732355508325ae6d80502fb5af1d