### PR TITLE
Add condition chips to grouped putter cards

### DIFF
--- a/app/putters/1.js
+++ b/app/putters/1.js
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import MarketSnapshot from "@/components/MarketSnapshot";
+import ConditionChips from "@/components/ConditionChips";
 
 // ---------- helpers ----------
 function formatPrice(value, currency = "USD") {
@@ -522,7 +523,9 @@ export default function PuttersPage() {
               const lows = lowsByModel[g.model];
 
               // pick best listing url for copy
-              const bestUrl = ordered.length ? ordered[0]?.url : null;
+              const firstOffer = ordered[0] ?? null;
+              const helperModelKey = firstOffer?.model || firstOffer?.groupModel || g.model;
+              const bestUrl = firstOffer?.url ?? null;
 
               return (
                 <article key={g.model} className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
@@ -563,6 +566,9 @@ export default function PuttersPage() {
                             </span>
                           )}
                         </div>
+                        {helperModelKey ? (
+                          <ConditionChips model={helperModelKey} className="mt-2" />
+                        ) : null}
 
                         {/* NEW: Lows row */}
                         {isOpen && (

--- a/app/putters/page.js
+++ b/app/putters/page.js
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import MarketSnapshot from "@/components/MarketSnapshot";
 import PriceSparkline from "@/components/PriceSparkline";
+import ConditionChips from "@/components/ConditionChips";
 import SmartPriceBadge from "@/components/SmartPriceBadge";
 import HeroSection from "@/components/HeroSection";
 import SectionWrapper from "@/components/SectionWrapper";
@@ -1304,6 +1305,10 @@ export default function PuttersPage() {
                                     </span>
                                   )}
                                 </div>
+
+                                {helperModelKey ? (
+                                  <ConditionChips model={helperModelKey} className="mt-2" />
+                                ) : null}
 
                                 <div className="mt-2">
                                   <SmartPriceBadge

--- a/app/putters/page2.js
+++ b/app/putters/page2.js
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { usePathname } from "next/navigation";
 import MarketSnapshot from "@/components/MarketSnapshot";
 import PriceSparkline from "@/components/PriceSparkline";
+import ConditionChips from "@/components/ConditionChips";
 import SmartPriceBadge from "@/components/SmartPriceBadge";
 
 
@@ -952,7 +953,9 @@ export default function PuttersPage() {
               const statsKey = getStatsKey(g.model, groupCond);
               const stats = statsByModel[statsKey] || null;
 
-              const bestUrl = ordered.length ? ordered[0]?.url : null;
+              const firstOffer = ordered[0] ?? null;
+              const helperModelKey = firstOffer ? getModelKey(firstOffer) : g.model;
+              const bestUrl = firstOffer?.url ?? null;
 
               const fair = fairPriceBadge(g.bestPrice, stats);
 
@@ -1005,6 +1008,9 @@ export default function PuttersPage() {
                             </span>
                           )}
                         </div>
+                        {helperModelKey ? (
+                          <ConditionChips model={helperModelKey} className="mt-2" />
+                        ) : null}
 			<div className="mt-2">
   <SmartPriceBadge
     price={Number(g.bestPrice)}

--- a/app/putters/temp.js
+++ b/app/putters/temp.js
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import MarketSnapshot from "@/components/MarketSnapshot";
 import PriceSparkline from "@/components/PriceSparkline";
+import ConditionChips from "@/components/ConditionChips";
 
 /* ============================
    SMART FAIR-PRICE BADGE (inline)
@@ -935,7 +936,9 @@ export default function PuttersPage() {
               const series = seriesByModel[g.model] || [];
               const stats = statsByModel[g.model] || null;
 
-              const bestUrl = ordered.length ? ordered[0]?.url : null;
+              const firstOffer = ordered[0] ?? null;
+              const helperModelKey = firstOffer ? getModelKey(firstOffer) : g.model;
+              const bestUrl = firstOffer?.url ?? null;
 
               const fair = fairPriceBadge(g.bestPrice, stats);
 
@@ -988,6 +991,9 @@ export default function PuttersPage() {
                             </span>
                           )}
                         </div>
+                        {helperModelKey ? (
+                          <ConditionChips model={helperModelKey} className="mt-2" />
+                        ) : null}
 
                         {/* Lows row (on expand) */}
                         {isOpen && (


### PR DESCRIPTION
## Summary
- surface condition delta chips on grouped putter cards using the derived helper model key
- ensure the condition chip widget is imported and rendered across legacy grouped page variants for parity

## Testing
- not run (project has no lint script)


------
https://chatgpt.com/codex/tasks/task_e_68dec2a85ab08325a4cd102d008cc257