### PR TITLE
Add baseline no-filter browse attempts

### DIFF
--- a/app/api/admin/fetch-browse/route.js
+++ b/app/api/admin/fetch-browse/route.js
@@ -307,6 +307,26 @@ function buildAttemptConfigs({ rawQuery, conditions, conditionIds, allBuying, mo
   };
   attempts.push(baseAttempt);
 
+  attempts.push({
+    ...baseAttempt,
+    label: "baseline-no-filter",
+    categoryId: CATEGORY_GOLF_CLUBS,
+    addPutterWord: true,
+    allBuying: false,
+    conditions: null,
+    conditionIds: [],
+  });
+
+  attempts.push({
+    ...baseAttempt,
+    label: "baseline-no-filter+auctions",
+    categoryId: CATEGORY_GOLF_CLUBS,
+    addPutterWord: true,
+    allBuying: true,
+    conditions: null,
+    conditionIds: [],
+  });
+
   attempts.push({ ...baseAttempt, label: "category", categoryId: CATEGORY_GOLF_CLUBS });
 
   attempts.push({


### PR DESCRIPTION
## Summary
- add early baseline golf club browse attempts that bypass condition filters

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df526ba5ac83259a51428b13e587e0