### PR TITLE
Include window metadata in resolved model history response

### DIFF
--- a/pages/api/model-history.js
+++ b/pages/api/model-history.js
@@ -116,7 +116,7 @@ export default async function handler(req, res) {
     return res.status(200).json({
       ok: true,
       requested: { modelKey: requested, windowDays },
-      resolved: { modelKey: picked },
+      resolved: { modelKey: picked, windowDays },
       series: {
         points,
         bands: Array.from(


### PR DESCRIPTION
## Summary
- include the active windowDays in the resolved payload of the model history API response
- keep requested metadata and series payload unchanged

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e02e03d9488325a3e6b43b41e4d5b5