### PR TITLE
Implement nightly cron seeding from seed file

### DIFF
--- a/app/api/cron/nightly/route.js
+++ b/app/api/cron/nightly/route.js
@@ -1,82 +1,88 @@
-// app/api/cron/nightly/route.js
-export const runtime = 'nodejs';
+export const runtime = "nodejs";
 
-import { NextResponse } from 'next/server';
+import fs from "node:fs/promises";
+import path from "node:path";
 
-function getBase(req) {
-  // Prefer explicit envs, else derive from the incoming request
-  const envBase =
-    process.env.NEXT_PUBLIC_SITE_URL ||
-    process.env.NEXT_PUBLIC_BASE_URL ||
-    '';
-  if (envBase.startsWith('http')) return envBase.replace(/\/+$/, '');
-
-  // Derive from request URL (has protocol + host in Next route handlers)
-  const origin = req.nextUrl?.origin || '';
-  return origin.replace(/\/+$/, '');
+async function readLines(p) {
+  const raw = await fs.readFile(path.resolve(p), "utf8");
+  return raw
+    .split(/\r?\n/)
+    .map((s) => s.trim())
+    .filter((s) => s && !s.startsWith("#"));
 }
 
-function adminKey() {
-  return process.env.ADMIN_KEY || process.env.CRON_SECRET || '';
-}
-
-async function postJson(url, headers = {}) {
-  const res = await fetch(url, { method: 'POST', headers, body: '' });
-  const text = await res.text();
-  let json = null;
-  try { json = JSON.parse(text); } catch (_) {}
-  return { status: res.status, json, text };
+function json(res, init) {
+  return Response.json(res, init);
 }
 
 export async function GET(req) {
-  const url = new URL(req.url);
-  const secret = url.searchParams.get('secret') || '';
-  const allowed = [process.env.CRON_SECRET, process.env.ADMIN_KEY].filter(Boolean);
-  if (!allowed.includes(secret)) {
-    return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
-  }
-
-  const base = getBase(req);
-  const key = adminKey();
-  const hdrs = { 'X-ADMIN-KEY': key };
-
-  const models = [
-    'Scotty Cameron Newport 2',
-    'Scotty Cameron Squareback 2',
-    'Odyssey White Hot OG Rossie',
-    'TaylorMade Spider Tour',
-    'Ping Anser',
-  ];
-
-  const seedResults = [];
-  for (const m of models) {
-    const u = `${base}/api/admin/fetch-browse?limit=50&model=${encodeURIComponent(m)}`;
-    try {
-      const r = await postJson(u, hdrs);
-      if (r.json?.ok) {
-        seedResults.push({ model: m, ok: true, saw: r.json.saw, inserted: r.json.inserted, usedUrl: r.json.usedUrl || '' });
-      } else {
-        seedResults.push({
-          model: m,
-          ok: false,
-          status: r.status,
-          error: r.json?.error || `non-JSON (${r.status})`,
-          sample: r.json?.sample ? true : false,
-        });
-      }
-    } catch (e) {
-      seedResults.push({ model: m, ok: false, error: String(e) });
-    }
-  }
-
-  // Kick aggregates (60/90/180) if you have /api/admin/aggregate
-  let aggregate = {};
   try {
-    const a = await postJson(`${base}/api/admin/aggregate?secret=${encodeURIComponent(key)}`);
-    aggregate = a.json || { status: a.status, body: a.text?.slice(0, 200) };
-  } catch (e) {
-    aggregate = { error: String(e) };
-  }
+    const url = new URL(req.url);
+    const secret = url.searchParams.get("secret") || "";
+    if (!process.env.CRON_SECRET || secret !== process.env.CRON_SECRET) {
+      return json({ ok: false, error: "unauthorized" }, { status: 401 });
+    }
 
-  return NextResponse.json({ ok: true, base, seedResults, aggregate });
+    let limit = Number(url.searchParams.get("limit") || 50);
+    if (!Number.isFinite(limit) || limit <= 0) limit = 50;
+    let pause = Number(url.searchParams.get("pause") || 1200);
+    if (!Number.isFinite(pause) || pause < 0) pause = 0;
+    const file = url.searchParams.get("file") || "data/seed-models.txt";
+
+    const origin = url.origin;
+    const adminKey = process.env.ADMIN_KEY;
+    if (!adminKey) {
+      return json({ ok: false, error: "missing ADMIN_KEY env" }, { status: 500 });
+    }
+
+    const models = await readLines(file);
+    const seeded = [];
+    for (const model of models) {
+      const target = new URL(`${origin}/api/admin/fetch-browse`);
+      target.searchParams.set("limit", String(limit));
+      target.searchParams.set("model", model);
+
+      const resp = await fetch(target.toString(), {
+        method: "POST",
+        headers: { "X-ADMIN-KEY": adminKey, "Content-Type": "application/json" },
+        body: "",
+      });
+
+      let jsonBody = null;
+      try {
+        jsonBody = await resp.json();
+      } catch (_) {
+        // ignore non-JSON responses
+      }
+      seeded.push({
+        model,
+        ok: Boolean(jsonBody?.ok),
+        saw: jsonBody?.saw || 0,
+        inserted: jsonBody?.inserted || 0,
+        status: resp.status,
+      });
+
+      if (pause > 0) {
+        await new Promise((resolve) => setTimeout(resolve, pause));
+      }
+    }
+
+    const aggUrl = `${origin}/api/admin/aggregate?secret=${encodeURIComponent(
+      process.env.CRON_SECRET
+    )}`;
+    const aggResp = await fetch(aggUrl);
+    let aggregate = { status: aggResp.status };
+    try {
+      const aggJson = await aggResp.json();
+      if (aggJson && typeof aggJson === "object") {
+        aggregate = aggJson;
+      }
+    } catch (_) {
+      // ignore non-JSON responses
+    }
+
+    return json({ ok: true, seeded, aggregate });
+  } catch (e) {
+    return json({ ok: false, error: e.message }, { status: 500 });
+  }
 }


### PR DESCRIPTION
## Summary
- update nightly cron route to read seed models from a configurable file
- post each model to the internal fetch endpoint with throttling and admin auth
- trigger the aggregate endpoint after seeding completes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e09ff18ab48325a84fa529c553fca5