### PR TITLE
Add deal grading to top deals

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -92,6 +92,10 @@ export default async function Home() {
     const currency = item?.currency || item?.bestOffer?.currency || "USD";
     const savingsAmount = safeNumber(item?.savings?.amount);
     const savingsPercent = safeNumber(item?.savings?.percent);
+    const hasGrade = item && typeof item === "object" && item.grade && typeof item.grade === "object";
+    const gradeLetter = hasGrade && typeof item.grade.letter === "string" ? item.grade.letter : null;
+    const gradeSavingsAmount = safeNumber(item?.grade?.savingsAmount);
+    const gradeSavingsPct = safeNumber(item?.grade?.savingsPct);
     const roundedPct = Number.isFinite(savingsPercent) ? Math.round(savingsPercent * 100) : null;
     const blurb =
       item?.blurb ||
@@ -111,6 +115,13 @@ export default async function Home() {
       currency,
       image: item?.image || item?.bestOffer?.image || null,
       totalListings: safeNumber(item?.totalListings),
+      grade: hasGrade
+        ? {
+            letter: gradeLetter,
+            savingsAmount: Number.isFinite(gradeSavingsAmount) ? gradeSavingsAmount : null,
+            savingsPct: Number.isFinite(gradeSavingsPct) ? gradeSavingsPct : null,
+          }
+        : null,
       savings: {
         amount: Number.isFinite(savingsAmount) ? savingsAmount : null,
         percent: Number.isFinite(savingsPercent) ? savingsPercent : null,
@@ -303,6 +314,31 @@ export default async function Home() {
                   typeof deal?.bestOffer?.url === "string" && deal.bestOffer.url.trim().length > 0
                     ? deal.bestOffer.url
                     : "";
+                const gradeLetter =
+                  typeof deal?.grade?.letter === "string" ? deal.grade.letter : null;
+                const gradeSavingsPct =
+                  Number.isFinite(deal?.grade?.savingsPct) ? Number(deal.grade.savingsPct) : null;
+                const showGradeBadge = Boolean(gradeLetter && gradeLetter !== "—");
+                const gradeTooltip = showGradeBadge
+                  ? gradeLetter === "F"
+                    ? "At/above typical"
+                    : gradeSavingsPct !== null
+                      ? `~${Math.round(gradeSavingsPct * 100)}% below typical`
+                      : "Below typical"
+                  : null;
+                const gradeClassName = showGradeBadge
+                  ? `inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${
+                      gradeLetter === "A"
+                        ? "bg-green-600 text-white"
+                        : gradeLetter === "B"
+                          ? "bg-green-200 text-green-900"
+                          : gradeLetter === "C"
+                            ? "bg-slate-200 text-slate-900"
+                            : gradeLetter === "D"
+                              ? "bg-amber-100 text-amber-900"
+                              : "border border-slate-300 text-slate-700"
+                    }`
+                  : "";
                 return (
                   <HighlightCard key={deal.query}>
                     <div className="aspect-[3/2] w-full bg-slate-100">
@@ -323,11 +359,18 @@ export default async function Home() {
                         <div className="flex flex-wrap items-center justify-between gap-3">
                           <div>
                             <p className="text-xs uppercase tracking-wide text-slate-500">Best live ask</p>
-                            <p className="text-2xl font-semibold text-slate-900">
-                              {Number.isFinite(deal.bestPrice)
-                                ? formatCurrency(deal.bestPrice, deal.currency)
-                                : "Price updating"}
-                            </p>
+                            <div className="flex items-center gap-2">
+                              <span className="text-2xl font-semibold text-slate-900">
+                                {Number.isFinite(deal.bestPrice)
+                                  ? formatCurrency(deal.bestPrice, deal.currency)
+                                  : "Price updating"}
+                              </span>
+                              {showGradeBadge ? (
+                                <span className={gradeClassName} title={gradeTooltip}>
+                                  {gradeLetter}
+                                </span>
+                              ) : null}
+                            </div>
                           </div>
                           {Number.isFinite(deal.bestPrice) && (
                             <SmartPriceBadge

--- a/lib/deal-grade.js
+++ b/lib/deal-grade.js
@@ -1,0 +1,28 @@
+// lib/deal-grade.js
+// Grades a deal vs the model median (p50). Keeps logic simple and explainable.
+
+export function computeSavings(total, p50Cents) {
+  const p50 = Number(p50Cents || 0) / 100;
+  const t = Number(total || 0);
+  if (!Number.isFinite(p50) || p50 <= 0 || !Number.isFinite(t) || t <= 0) {
+    return { amount: 0, pct: 0 };
+  }
+  const amount = Math.max(0, p50 - t);
+  const pct = amount / p50;
+  return { amount, pct };
+}
+
+// Simple banding; we can later tune by dispersion, sample size, or condition.
+export function gradeFromPct(pct) {
+  if (!Number.isFinite(pct)) return "—";
+  if (pct >= 0.30) return "A";
+  if (pct >= 0.20) return "B";
+  if (pct >= 0.10) return "C";
+  if (pct > 0.0) return "D";
+  return "F"; // at/above median price, not a "deal"
+}
+
+export function dealGrade(total, p50Cents) {
+  const { amount, pct } = computeSavings(total, p50Cents);
+  return { letter: gradeFromPct(pct), savingsAmount: amount, savingsPct: pct };
+}

--- a/pages/api/__tests__/top-deals.test.js
+++ b/pages/api/__tests__/top-deals.test.js
@@ -71,6 +71,9 @@ test("loadRankedDeals returns listings observed before midnight when window is r
     assert.equal(deal.label, "Acme");
     assert.equal(deal.savings.amount, 60);
     assert.equal(Math.round(deal.savings.percent * 100) / 100, 0.4);
+    assert.ok(deal.grade);
+    assert.equal(deal.grade.letter, "A");
+    assert.equal(Math.round(deal.grade.savingsPct * 100) / 100, 0.4);
   } finally {
     Date.now = originalNow;
   }
@@ -184,6 +187,9 @@ test("buildDealsFromRows decorates URLs with affiliate params when configured", 
     assert.equal(decorated.searchParams.get("mkevt"), process.env.EPN_MKEVT);
     assert.equal(decorated.searchParams.get("campid"), "987654");
     assert.equal(decorated.searchParams.get("foo"), "bar");
+    assert.ok(deal.grade);
+    assert.equal(deal.grade.letter, "A");
+    assert.equal(Math.round(deal.grade.savingsPct * 100) / 100, 0.4);
   } finally {
     process.env.EPN_CAMPID = originalEnv.campid;
     process.env.EPN_CUSTOMID = originalEnv.customid;

--- a/pages/api/top-deals.js
+++ b/pages/api/top-deals.js
@@ -11,6 +11,7 @@ import {
   HEAD_COVER_TEXT_RX,
 } from "../../lib/sanitizeModelKey.js";
 import { decorateEbayUrl } from "../../lib/affiliate.js";
+import { dealGrade } from "../../lib/deal-grade.js";
 
 const CATALOG_LOOKUP = (() => {
   const map = new Map();
@@ -506,6 +507,8 @@ export function buildDealsFromRows(rows, limit, lookbackHours = null) {
       brand: row.brand || null,
     };
 
+    const grade = dealGrade(total, row.p50_cents);
+
     return {
       modelKey: row.model_key,
       label,
@@ -517,6 +520,11 @@ export function buildDealsFromRows(rows, limit, lookbackHours = null) {
       stats,
       statsMeta,
       totalListings: toNumber(row.listing_count),
+      grade: {
+        letter: typeof grade.letter === "string" ? grade.letter : null,
+        savingsAmount: Number.isFinite(grade.savingsAmount) ? grade.savingsAmount : null,
+        savingsPct: Number.isFinite(grade.savingsPct) ? grade.savingsPct : null,
+      },
       savings: {
         amount: Number.isFinite(savingsAmount) ? savingsAmount : null,
         percent: Number.isFinite(savingsPercent) ? savingsPercent : null,


### PR DESCRIPTION
## Summary
- add a shared deal-grading helper for computing savings vs the model median
- return per-listing deal grades from the top deals API and cover them with tests
- surface the grade badge on homepage deal cards next to the live ask price

## Testing
- node --test pages/api/__tests__/top-deals.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1f4bd22848325ada93be3e32a761e