### PR TITLE
Add deal grading badges to top deals

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { headers } from "next/headers";
 import SmartPriceBadge from "@/components/SmartPriceBadge";
+import DealGradeBadge from "@/components/DealGradeBadge";
 import MarketSnapshot from "@/components/MarketSnapshot";
 import HeroSection from "@/components/HeroSection";
 import SectionWrapper from "@/components/SectionWrapper";
@@ -94,8 +95,9 @@ export default async function Home() {
     const savingsPercent = safeNumber(item?.savings?.percent);
     const hasGrade = item && typeof item === "object" && item.grade && typeof item.grade === "object";
     const gradeLetter = hasGrade && typeof item.grade.letter === "string" ? item.grade.letter : null;
-    const gradeSavingsAmount = safeNumber(item?.grade?.savingsAmount);
-    const gradeSavingsPct = safeNumber(item?.grade?.savingsPct);
+    const gradeLabel = hasGrade && typeof item.grade.label === "string" ? item.grade.label : null;
+    const gradeColor = hasGrade && typeof item.grade.color === "string" ? item.grade.color : null;
+    const gradeDeltaPct = safeNumber(item?.grade?.deltaPct);
     const roundedPct = Number.isFinite(savingsPercent) ? Math.round(savingsPercent * 100) : null;
     const blurb =
       item?.blurb ||
@@ -118,8 +120,9 @@ export default async function Home() {
       grade: hasGrade
         ? {
             letter: gradeLetter,
-            savingsAmount: Number.isFinite(gradeSavingsAmount) ? gradeSavingsAmount : null,
-            savingsPct: Number.isFinite(gradeSavingsPct) ? gradeSavingsPct : null,
+            label: gradeLabel,
+            color: gradeColor,
+            deltaPct: Number.isFinite(gradeDeltaPct) ? gradeDeltaPct : null,
           }
         : null,
       savings: {
@@ -239,13 +242,16 @@ export default async function Home() {
                       : "We compare every listing against recent live listing percentiles. Smart Price highlights the standouts as soon as fresh baseline data confirms the savings."}
                   </p>
                 </div>
-                <SmartPriceBadge
-                  price={smartExample.bestPrice}
-                  baseStats={smartExample.stats}
-                  title={smartExample.bestOffer?.title}
-                  specs={smartExample.bestOffer?.specs}
-                  brand={smartExample.bestOffer?.brand}
-                />
+                <div className="flex flex-col items-start gap-2">
+                  <SmartPriceBadge
+                    price={smartExample.bestPrice}
+                    baseStats={smartExample.stats}
+                    title={smartExample.bestOffer?.title}
+                    specs={smartExample.bestOffer?.specs}
+                    brand={smartExample.bestOffer?.brand}
+                  />
+                  {smartExample.grade ? <DealGradeBadge grade={smartExample.grade} /> : null}
+                </div>
               </div>
             </div>
           ) : (
@@ -314,31 +320,7 @@ export default async function Home() {
                   typeof deal?.bestOffer?.url === "string" && deal.bestOffer.url.trim().length > 0
                     ? deal.bestOffer.url
                     : "";
-                const gradeLetter =
-                  typeof deal?.grade?.letter === "string" ? deal.grade.letter : null;
-                const gradeSavingsPct =
-                  Number.isFinite(deal?.grade?.savingsPct) ? Number(deal.grade.savingsPct) : null;
-                const showGradeBadge = Boolean(gradeLetter && gradeLetter !== "—");
-                const gradeTooltip = showGradeBadge
-                  ? gradeLetter === "F"
-                    ? "At/above typical"
-                    : gradeSavingsPct !== null
-                      ? `~${Math.round(gradeSavingsPct * 100)}% below typical`
-                      : "Below typical"
-                  : null;
-                const gradeClassName = showGradeBadge
-                  ? `inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${
-                      gradeLetter === "A"
-                        ? "bg-green-600 text-white"
-                        : gradeLetter === "B"
-                          ? "bg-green-200 text-green-900"
-                          : gradeLetter === "C"
-                            ? "bg-slate-200 text-slate-900"
-                            : gradeLetter === "D"
-                              ? "bg-amber-100 text-amber-900"
-                              : "border border-slate-300 text-slate-700"
-                    }`
-                  : "";
+                const grade = deal && typeof deal.grade === "object" ? deal.grade : null;
                 return (
                   <HighlightCard key={deal.query}>
                     <div className="aspect-[3/2] w-full bg-slate-100">
@@ -365,11 +347,7 @@ export default async function Home() {
                                   ? formatCurrency(deal.bestPrice, deal.currency)
                                   : "Price updating"}
                               </span>
-                              {showGradeBadge ? (
-                                <span className={gradeClassName} title={gradeTooltip}>
-                                  {gradeLetter}
-                                </span>
-                              ) : null}
+                              {grade ? <DealGradeBadge grade={grade} /> : null}
                             </div>
                           </div>
                           {Number.isFinite(deal.bestPrice) && (

--- a/components/DealGradeBadge.jsx
+++ b/components/DealGradeBadge.jsx
@@ -1,0 +1,61 @@
+"use client";
+
+import clsx from "clsx";
+
+const COLOR_VARIANTS = {
+  green: "border-green-200/80 bg-green-100/80 text-green-900",
+  emerald: "border-emerald-200/80 bg-emerald-100/80 text-emerald-900",
+  slate: "border-slate-300/70 bg-slate-200/70 text-slate-900",
+  red: "border-red-200/80 bg-red-100/80 text-red-900",
+};
+
+function formatPercent(value) {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  const percentage = Math.abs(value * 100);
+  if (!Number.isFinite(percentage)) return null;
+  if (percentage >= 10) return `${Math.round(percentage)}%`;
+  if (percentage >= 1) return `${percentage.toFixed(1).replace(/\.0$/, "")}%`;
+  return `${percentage.toFixed(2).replace(/0+$/, "").replace(/\.$/, "")}%`;
+}
+
+export default function DealGradeBadge({ grade, className = "" }) {
+  if (!grade || typeof grade !== "object") return null;
+  const letter = typeof grade.letter === "string" ? grade.letter.toUpperCase() : null;
+  const label = typeof grade.label === "string" ? grade.label : null;
+  const colorKey = typeof grade.color === "string" ? grade.color : null;
+  const deltaPct = typeof grade.deltaPct === "number" && Number.isFinite(grade.deltaPct) ? grade.deltaPct : null;
+
+  if (!letter) return null;
+
+  const arrowThreshold = 0.005; // ±0.5%
+  const arrow = deltaPct != null && Math.abs(deltaPct) >= arrowThreshold ? (deltaPct > 0 ? "↓" : "↑") : null;
+  const percentLabel = arrow ? formatPercent(deltaPct) : null;
+  const toneClass = colorKey && COLOR_VARIANTS[colorKey] ? COLOR_VARIANTS[colorKey] : COLOR_VARIANTS.slate;
+  const titleParts = [];
+  if (letter) titleParts.push(`Grade ${letter}`);
+  if (label) titleParts.push(label);
+  if (percentLabel) titleParts.push(`${arrow === "↓" ? "below" : "above"} median by ${percentLabel}`);
+
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-medium",
+        toneClass,
+        className
+      )}
+      title={titleParts.join(" · ") || undefined}
+      aria-label={titleParts.join(" · ") || undefined}
+    >
+      <span className="flex items-center gap-1">
+        <span className="font-semibold">{letter}</span>
+        {label ? <span className="tracking-wide">{label}</span> : null}
+      </span>
+      {arrow && percentLabel ? (
+        <span className="flex items-center gap-1 text-[11px] font-normal">
+          <span aria-hidden>{arrow}</span>
+          <span>{percentLabel}</span>
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/components/PriceComparisonTable.jsx
+++ b/components/PriceComparisonTable.jsx
@@ -1,4 +1,4 @@
-import SmartPriceBadge from "@/components/SmartPriceBadge";
+import DealGradeBadge from "@/components/DealGradeBadge";
 
 function formatCurrency(value, currency = "USD") {
   if (typeof value !== "number" || !Number.isFinite(value)) return "—";
@@ -42,6 +42,7 @@ export default function PriceComparisonTable({ deals = [] }) {
           rawSavings,
           hasPositiveSavings,
           percentSavings,
+          grade: deal && typeof deal.grade === "object" ? deal.grade : null,
         };
       })
     : [];
@@ -82,13 +83,14 @@ export default function PriceComparisonTable({ deals = [] }) {
                     Listings
                   </th>
                   <th scope="col" className="px-6 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                    Tier
+                    Grade
                   </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-200">
                 {rows.map((row) => {
-                  const { deal, label, bestPrice, median, rawSavings, hasPositiveSavings, percentSavings, totalListings } = row;
+                  const { label, bestPrice, median, rawSavings, hasPositiveSavings, percentSavings, totalListings, grade } =
+                    row;
                   const savingsLabel = hasPositiveSavings
                     ? `${formatCurrency(rawSavings, row.currency)}${
                         percentSavings ? ` (${formatPercent(percentSavings)})` : ""
@@ -114,17 +116,7 @@ export default function PriceComparisonTable({ deals = [] }) {
                         {Number.isFinite(totalListings) ? totalListings : "—"}
                       </td>
                       <td className="px-6 py-4 text-sm">
-                        {Number.isFinite(bestPrice) ? (
-                          <SmartPriceBadge
-                            price={bestPrice}
-                            baseStats={deal?.stats}
-                            title={deal?.bestOffer?.title}
-                            specs={deal?.bestOffer?.specs}
-                            brand={deal?.bestOffer?.brand}
-                          />
-                        ) : (
-                          <span className="text-slate-400">—</span>
-                        )}
+                        {grade ? <DealGradeBadge grade={grade} /> : <span className="text-slate-400">—</span>}
                       </td>
                     </tr>
                   );
@@ -135,7 +127,7 @@ export default function PriceComparisonTable({ deals = [] }) {
 
           <div className="space-y-4 p-4 md:hidden">
             {rows.map((row) => {
-              const { deal, label, bestPrice, median, rawSavings, hasPositiveSavings, percentSavings, totalListings } = row;
+              const { label, bestPrice, median, rawSavings, hasPositiveSavings, percentSavings, totalListings, grade } = row;
               const savingsLabel = hasPositiveSavings
                 ? `${formatCurrency(rawSavings, row.currency)}${
                     percentSavings ? ` (${formatPercent(percentSavings)})` : ""
@@ -151,15 +143,7 @@ export default function PriceComparisonTable({ deals = [] }) {
                         <p className="mt-1 text-xs text-slate-500">Tracking {totalListings} live listings</p>
                       )}
                     </div>
-                    {Number.isFinite(bestPrice) ? (
-                      <SmartPriceBadge
-                        price={bestPrice}
-                        baseStats={deal?.stats}
-                        title={deal?.bestOffer?.title}
-                        specs={deal?.bestOffer?.specs}
-                        brand={deal?.bestOffer?.brand}
-                      />
-                    ) : null}
+                    {grade ? <DealGradeBadge grade={grade} /> : null}
                   </div>
                   <dl className="mt-4 grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
                     <div>

--- a/lib/deal-grade.js
+++ b/lib/deal-grade.js
@@ -1,28 +1,48 @@
-// lib/deal-grade.js
-// Grades a deal vs the model median (p50). Keeps logic simple and explainable.
+const LETTER_META = {
+  A: { label: "Great", color: "green" },
+  B: { label: "Good", color: "emerald" },
+  C: { label: "Fair", color: "slate" },
+  D: { label: "Over", color: "red" },
+};
 
-export function computeSavings(total, p50Cents) {
-  const p50 = Number(p50Cents || 0) / 100;
-  const t = Number(total || 0);
-  if (!Number.isFinite(p50) || p50 <= 0 || !Number.isFinite(t) || t <= 0) {
-    return { amount: 0, pct: 0 };
+function toFiniteNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+export function gradeDeal({ total, p10, p50, p90, dispersionRatio } = {}) {
+  const totalNum = toFiniteNumber(total);
+  const median = toFiniteNumber(p50);
+
+  if (!Number.isFinite(totalNum) || !Number.isFinite(median) || median <= 0) {
+    return { letter: null, label: null, color: null, deltaPct: null };
   }
-  const amount = Math.max(0, p50 - t);
-  const pct = amount / p50;
-  return { amount, pct };
-}
 
-// Simple banding; we can later tune by dispersion, sample size, or condition.
-export function gradeFromPct(pct) {
-  if (!Number.isFinite(pct)) return "—";
-  if (pct >= 0.30) return "A";
-  if (pct >= 0.20) return "B";
-  if (pct >= 0.10) return "C";
-  if (pct > 0.0) return "D";
-  return "F"; // at/above median price, not a "deal"
-}
+  const lower = toFiniteNumber(p10);
+  const upper = toFiniteNumber(p90);
+  const deltaPct = Number.isFinite(median) && median !== 0 ? (median - totalNum) / median : null;
 
-export function dealGrade(total, p50Cents) {
-  const { amount, pct } = computeSavings(total, p50Cents);
-  return { letter: gradeFromPct(pct), savingsAmount: amount, savingsPct: pct };
+  let letter = "D";
+
+  if (Number.isFinite(lower) && totalNum <= lower) {
+    letter = "A";
+  } else if (Number.isFinite(median) && totalNum <= median * 0.9) {
+    letter = "B";
+  } else if (Number.isFinite(upper) && totalNum <= upper) {
+    letter = "C";
+  }
+
+  const dispersion = toFiniteNumber(dispersionRatio);
+  if (Number.isFinite(dispersion) && dispersion > 1.5 && letter === "A") {
+    letter = "B";
+  }
+
+  const meta = LETTER_META[letter] || { label: null, color: null };
+
+  return {
+    letter,
+    label: meta.label,
+    color: meta.color,
+    deltaPct: Number.isFinite(deltaPct) ? deltaPct : null,
+  };
 }

--- a/pages/api/__tests__/top-deals.test.js
+++ b/pages/api/__tests__/top-deals.test.js
@@ -73,7 +73,9 @@ test("loadRankedDeals returns listings observed before midnight when window is r
     assert.equal(Math.round(deal.savings.percent * 100) / 100, 0.4);
     assert.ok(deal.grade);
     assert.equal(deal.grade.letter, "A");
-    assert.equal(Math.round(deal.grade.savingsPct * 100) / 100, 0.4);
+    assert.equal(deal.grade.label, "Great");
+    assert.equal(deal.grade.color, "green");
+    assert.equal(Math.round(deal.grade.deltaPct * 100) / 100, 0.4);
   } finally {
     Date.now = originalNow;
   }
@@ -189,7 +191,9 @@ test("buildDealsFromRows decorates URLs with affiliate params when configured", 
     assert.equal(decorated.searchParams.get("foo"), "bar");
     assert.ok(deal.grade);
     assert.equal(deal.grade.letter, "A");
-    assert.equal(Math.round(deal.grade.savingsPct * 100) / 100, 0.4);
+    assert.equal(deal.grade.label, "Great");
+    assert.equal(deal.grade.color, "green");
+    assert.equal(Math.round(deal.grade.deltaPct * 100) / 100, 0.4);
   } finally {
     process.env.EPN_CAMPID = originalEnv.campid;
     process.env.EPN_CUSTOMID = originalEnv.customid;

--- a/pages/api/top-deals.js
+++ b/pages/api/top-deals.js
@@ -11,7 +11,7 @@ import {
   HEAD_COVER_TEXT_RX,
 } from "../../lib/sanitizeModelKey.js";
 import { decorateEbayUrl } from "../../lib/affiliate.js";
-import { dealGrade } from "../../lib/deal-grade.js";
+import { gradeDeal } from "../../lib/deal-grade.js";
 
 const CATALOG_LOOKUP = (() => {
   const map = new Map();
@@ -507,7 +507,13 @@ export function buildDealsFromRows(rows, limit, lookbackHours = null) {
       brand: row.brand || null,
     };
 
-    const grade = dealGrade(total, row.p50_cents);
+    const grade = gradeDeal({
+      total,
+      p10: stats.p10,
+      p50: stats.p50,
+      p90: stats.p90,
+      dispersionRatio: stats.dispersionRatio,
+    });
 
     return {
       modelKey: row.model_key,
@@ -522,8 +528,9 @@ export function buildDealsFromRows(rows, limit, lookbackHours = null) {
       totalListings: toNumber(row.listing_count),
       grade: {
         letter: typeof grade.letter === "string" ? grade.letter : null,
-        savingsAmount: Number.isFinite(grade.savingsAmount) ? grade.savingsAmount : null,
-        savingsPct: Number.isFinite(grade.savingsPct) ? grade.savingsPct : null,
+        label: typeof grade.label === "string" ? grade.label : null,
+        color: typeof grade.color === "string" ? grade.color : null,
+        deltaPct: Number.isFinite(grade.deltaPct) ? grade.deltaPct : null,
       },
       savings: {
         amount: Number.isFinite(savingsAmount) ? savingsAmount : null,


### PR DESCRIPTION
## Summary
- add a gradeDeal helper that calculates letter, label, color, and delta for each offer
- wire the grading data into the top deals API response and extend the associated tests
- render the new deal grade badge across leaderboard tables, hero examples, and listing cards

## Testing
- node --test pages/api/__tests__/top-deals.test.js
- node --test pages/api/top-deals.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e34c2eaa988325b4f6c17832417147