### PR TITLE
Revise homepage deals and putter cards for condition bands

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -65,7 +65,7 @@ async function fetchJson(url, init) {
 export default async function Home() {
   const baseUrl = await resolveBaseUrl();
 
-  const topDealsPromise = fetchJson(`${baseUrl}/api/top-deals`, {
+  const topDealsPromise = fetchJson(`${baseUrl}/api/top-deals?cache=1&fast=1`, {
     next: { revalidate: 60 },
   });
 
@@ -113,6 +113,7 @@ export default async function Home() {
       bestOffer: item?.bestOffer || null,
       stats: item?.stats || null,
       statsMeta: item?.statsMeta || null,
+      modelKey: item?.modelKey || null,
       bestPrice: Number.isFinite(bestPrice) ? bestPrice : null,
       currency,
       image: item?.image || item?.bestOffer?.image || null,

--- a/components/TopDealsGrid.jsx
+++ b/components/TopDealsGrid.jsx
@@ -11,6 +11,13 @@ function fmt(n, currency = "USD") {
     }
 }
 
+const bandPretty = (b) => {
+    if (!b || typeof b !== "string") return null;
+    const upper = b.toUpperCase();
+    if (upper === "ANY") return null;
+    return upper.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+};
+
 export default function TopDealsGrid({ items = [] }) {
     if (!Array.isArray(items) || items.length === 0) return null;
 
@@ -19,76 +26,66 @@ export default function TopDealsGrid({ items = [] }) {
             {items.map((d) => {
                 const id = d?.bestOffer?.id || d?.id || d?.url;
                 const label = d?.label || d?.model || "Live Smart Price deal";
-                const best = Number(d?.bestOffer?.price);
-                const stats = d?.stats || {};
-                const n = Number(stats?.n ?? 0);
+                const bestPrice = Number.isFinite(Number(d?.bestPrice))
+                    ? Number(d.bestPrice)
+                    : Number(d?.bestOffer?.total ?? d?.bestOffer?.price);
+                const currency = d?.currency || d?.bestOffer?.currency || "USD";
+                const bandLabel = bandPretty(d?.stats?.usedBand);
+                const bandSampleRaw = Number(d?.statsMeta?.bandSampleSize);
+                const bandSample = Number.isFinite(bandSampleRaw) && bandSampleRaw > 0 ? bandSampleRaw : null;
 
                 return (
                     <article
-                        key={id}
-                        className="flex flex-col justify-between rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+                        key={id || label}
+                        className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
                     >
-                        {/* Header */}
                         <div className="flex items-start justify-between gap-3">
                             <div className="min-w-0">
                                 <h3 className="truncate text-base font-semibold text-slate-900">{label}</h3>
-                                <p className="mt-1 text-xs text-slate-500">
-                                    {n > 0 ? <>Median p50 tracked • n={n}</> : <>Building baseline…</>}
-                                </p>
+                                {d.modelKey ? (
+                                    <p className="mt-1 truncate text-xs text-slate-500">{d.modelKey}</p>
+                                ) : null}
                             </div>
-                            {/* Deal grade pill (reuses site-wide badge) */}
-                            {d.grade ? <DealGradeBadge grade={d.grade} /> : null}
+                            <div className="flex flex-col items-end gap-2">
+                                {d.grade ? <DealGradeBadge grade={d.grade} /> : null}
+                                {bandLabel ? (
+                                    <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-700">
+                                        {bandLabel}
+                                        {bandSample ? <span className="ml-1 opacity-70">n={bandSample}</span> : null}
+                                    </span>
+                                ) : null}
+                            </div>
                         </div>
 
-                        {/* Body */}
-                        <dl className="mt-4 grid grid-cols-2 gap-3 text-sm">
+                        <div className="flex items-end justify-between gap-3">
                             <div>
-                                <dt className="text-slate-500">Best live ask</dt>
-                                <dd className="font-medium">
-                                    {Number.isFinite(best) ? fmt(best, d.currency || "USD") : "—"}
-                                </dd>
+                                <p className="text-xs text-slate-500">Best live price</p>
+                                <p className="text-xl font-semibold text-slate-900">
+                                    {Number.isFinite(bestPrice) ? fmt(bestPrice, currency) : "—"}
+                                </p>
                             </div>
-                            <div>
-                                <dt className="text-slate-500">Median (p50)</dt>
-                                <dd className="font-medium">
-                                    {Number.isFinite(stats?.p50) ? fmt(stats.p50, d.currency || "USD") : "—"}
-                                </dd>
-                            </div>
-                            <div>
-                                <dt className="text-slate-500">Savings vs p50</dt>
-                                <dd className="font-medium">
-                                    {Number.isFinite(best) && Number.isFinite(stats?.p50) && stats.p50 > 0
-                                        ? `${Math.round(((best - stats.p50) / stats.p50) * -100)}%`
-                                        : "—"}
-                                </dd>
-                            </div>
-                            <div>
-                                <dt className="text-slate-500">Sample size</dt>
-                                <dd className="font-medium">{n || "—"}</dd>
-                            </div>
-                        </dl>
-
-                        {/* CTA */}
-                        <div className="mt-4 flex items-center justify-between">
                             {d.bestOffer?.url ? (
                                 <a
                                     href={d.bestOffer.url}
-                                    className="inline-flex items-center rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+                                    className="inline-flex items-center rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 transition hover:border-emerald-200 hover:text-emerald-700"
                                 >
                                     View listing
                                 </a>
                             ) : (
                                 <span className="text-sm text-slate-500">No live link</span>
                             )}
-                            {d.modelKey ? (
+                        </div>
+
+                        {d.modelKey ? (
+                            <div className="text-right text-xs">
                                 <Link
                                     href={`/putters?model=${encodeURIComponent(d.modelKey)}`}
-                                    className="text-sm font-medium text-emerald-700 hover:underline"
+                                    className="font-medium text-emerald-700 hover:underline"
                                 >
-                                    See model page →
+                                    Explore this model →
                                 </Link>
-                            ) : null}
-                        </div>
+                            </div>
+                        ) : null}
                     </article>
                 );
             })}


### PR DESCRIPTION
## Summary
- switch the homepage Top Deals fetch to the cached fast endpoint and carry modelKey through each deal payload
- restyle homepage deal cards to use the full label, highlight grade, and add the condition band chip with sample size
- streamline grouped and flat putter result cards with compact specs, condition/band chips, and slimmer layouts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5853e8174832582a6a1272137dd79