### PR TITLE
Refine deal grading and accessory filtering for top deals API

### DIFF
--- a/lib/deal-grade.js
+++ b/lib/deal-grade.js
@@ -1,12 +1,12 @@
 // lib/deal-grade.js
-// Deal grade vs p50 (median) using Corey’s thresholds:
-// A+ ≥ 40% below, A 25–40% below, B 15–25% below, C 5–15% below, else D (Over)
+// Deal grade thresholds (percentage below the in-band median):
+// A+ ≥ 40%, A ≥ 25%, B ≥ 15%, C ≥ 5%, else no grade.
+
 const LETTER_META = {
-  "A+": { label: "Great", color: "emerald" }, // badge uses emerald-600 text-white
-  A:    { label: "Great", color: "green"   }, // badge uses green-600 text-white
-  B:    { label: "Good",  color: "amber500"},
-  C:    { label: "Fair",  color: "amber300"},
-  D:    { label: "Over",  color: "red"     },
+  "A+": { label: "Exceptional", color: "emerald" },
+  A: { label: "Great", color: "emerald" },
+  B: { label: "Strong", color: "sky" },
+  C: { label: "Solid", color: "amber" },
 };
 
 function toFiniteNumber(value) {
@@ -14,27 +14,22 @@ function toFiniteNumber(value) {
   return Number.isFinite(num) ? num : null;
 }
 
-export function gradeDeal({ total, p50, p10, p90, dispersionRatio } = {}) {
-  const price = toFiniteNumber(total);
-  const median = toFiniteNumber(p50);
-  if (!Number.isFinite(price) || !Number.isFinite(median) || median <= 0) {
+export function gradeDeal({ savingsPct } = {}) {
+  const pct = toFiniteNumber(savingsPct);
+  if (!Number.isFinite(pct) || pct <= 0) {
     return { letter: null, label: null, color: null, deltaPct: null };
   }
 
-  const deltaPct = (price - median) / median; // negative = below median (better)
+  let letter = null;
+  if (pct >= 0.40) letter = "A+";
+  else if (pct >= 0.25) letter = "A";
+  else if (pct >= 0.15) letter = "B";
+  else if (pct >= 0.05) letter = "C";
 
-  let letter = "D"; // default = Over
-  if (deltaPct <= -0.40) letter = "A+";
-  else if (deltaPct <= -0.25) letter = "A";
-  else if (deltaPct <= -0.15) letter = "B";
-  else if (deltaPct <= -0.05) letter = "C";
-
-  // (Optional) knock down screaming A’s in highly dispersed markets:
-  const dispersion = toFiniteNumber(dispersionRatio);
-  if (letter === "A" && Number.isFinite(dispersion) && dispersion > 1.5) {
-    letter = "B";
+  if (!letter) {
+    return { letter: null, label: null, color: null, deltaPct: -pct };
   }
 
   const meta = LETTER_META[letter] || { label: null, color: null };
-  return { letter, label: meta.label, color: meta.color, deltaPct };
+  return { letter, label: meta.label, color: meta.color, deltaPct: -pct };
 }

--- a/pages/api/__tests__/top-deals.test.js
+++ b/pages/api/__tests__/top-deals.test.js
@@ -72,10 +72,13 @@ test("loadRankedDeals returns listings observed before midnight when window is r
     assert.equal(deal.savings.amount, 60);
     assert.equal(Math.round(deal.savings.percent * 100) / 100, 0.4);
     assert.ok(deal.grade);
-    assert.equal(deal.grade.letter, "A");
-    assert.equal(deal.grade.label, "Great");
-    assert.equal(deal.grade.color, "green");
-    assert.equal(Math.round(deal.grade.deltaPct * 100) / 100, 0.4);
+    assert.equal(deal.grade.letter, "A+");
+    assert.equal(deal.grade.label, "Exceptional");
+    assert.equal(deal.grade.color, "emerald");
+    assert.equal(Math.round(deal.grade.deltaPct * 100) / 100, -0.4);
+    assert.equal(deal.dealGrade, "A+");
+    assert.equal(Math.round(deal.savingsPct * 100) / 100, 0.4);
+    assert.ok(typeof deal.gradeReason === "string" && deal.gradeReason.length > 0);
   } finally {
     Date.now = originalNow;
   }
@@ -190,10 +193,10 @@ test("buildDealsFromRows decorates URLs with affiliate params when configured", 
     assert.equal(decorated.searchParams.get("campid"), "987654");
     assert.equal(decorated.searchParams.get("foo"), "bar");
     assert.ok(deal.grade);
-    assert.equal(deal.grade.letter, "A");
-    assert.equal(deal.grade.label, "Great");
-    assert.equal(deal.grade.color, "green");
-    assert.equal(Math.round(deal.grade.deltaPct * 100) / 100, 0.4);
+    assert.equal(deal.grade.letter, "A+");
+    assert.equal(deal.grade.label, "Exceptional");
+    assert.equal(deal.grade.color, "emerald");
+    assert.equal(Math.round(deal.grade.deltaPct * 100) / 100, -0.4);
   } finally {
     process.env.EPN_CAMPID = originalEnv.campid;
     process.env.EPN_CUSTOMID = originalEnv.customid;

--- a/pages/api/top-deals.js
+++ b/pages/api/top-deals.js
@@ -186,7 +186,9 @@ async function queryTopDeals(sql, since, modelKey = null) {
       amb.mod_band_n, amb.mod_band_p50_cents, amb.mod_band_window,
 
       -- Which band this listing is in
-      c.cond_band
+      c.cond_band,
+
+      COALESCE(v.variant_key, '') AS variant_key
 
     FROM latest_prices lp
     JOIN items i ON i.item_id = lp.item_id
@@ -306,20 +308,50 @@ export function buildDealsFromRows(rows, limit, arg3) {
     maxDispersion = null,
     minSavingsPct = 0,
     lookbackHours = null,
+    debugAccessoryList = null,
+    captureAccessoryDrops = false,
   } = opts;
 
   const grouped = new Map();
 
-  for (const row of rows) {
-    if (!isLikelyPutterTitle(row?.title || '')) continue;
-    if (isAccessoryDominatedTitle(row?.title || '')) continue;
+  const debugSink = Array.isArray(debugAccessoryList) ? debugAccessoryList : null;
 
+  for (const row of rows) {
+    const title = row?.title || '';
     const modelKey = row.model_key || '';
+    const knownModel = Boolean(modelKey);
+    const hasPutterToken = /\bputter\b/i.test(title);
+    const likelyTitle = isLikelyPutterTitle(title);
+
+    const recordDrop = (reason) => {
+      if (!captureAccessoryDrops || !debugSink) return;
+      const payload = { reason, title };
+      if (row?.item_id) payload.itemId = row.item_id;
+      if (row?.model_key) payload.modelKey = row.model_key;
+      debugSink.push(payload);
+    };
+
+    if (!hasPutterToken && !knownModel) {
+      recordDrop('missing_putter_token');
+      continue;
+    }
+
+    if (!likelyTitle && !knownModel) {
+      recordDrop('not_putter_title');
+      continue;
+    }
+
+    if (isAccessoryDominatedTitle(title)) {
+      recordDrop('accessory_dominated');
+      continue;
+    }
+
     if (!modelKey) continue;
 
     const total = toNumber(row.total);
     const price = toNumber(row.price);
     const shipping = toNumber(row.shipping);
+    const variantKey = typeof row.variant_key === 'string' ? row.variant_key : '';
 
     // ANY-band medians
     const varMedian = centsToNumber(row.var_p50_cents);
@@ -340,17 +372,34 @@ export function buildDealsFromRows(rows, limit, arg3) {
     let median = null;
     let bandSample = null;
     let bandUsed = null;
+    let medianSource = null;
+    let medianSample = null;
+
 
     if (Number.isFinite(varBandN) && varBandN >= (minSample ?? 0) && Number.isFinite(varBandMedian)) {
-      median = varBandMedian; bandSample = varBandN; bandUsed = usedBand;
+      median = varBandMedian;
+      bandSample = varBandN;
+      bandUsed = usedBand;
+      medianSource = 'variant_band';
+      medianSample = varBandN;
     } else if (Number.isFinite(modBandN) && modBandN >= (minSample ?? 0) && Number.isFinite(modBandMedian)) {
-      median = modBandMedian; bandSample = modBandN; bandUsed = usedBand;
+      median = modBandMedian;
+      bandSample = modBandN;
+      bandUsed = usedBand;
+      medianSource = 'model_band';
+      medianSample = modBandN;
     } else if (Number.isFinite(varN) && varN >= (minSample ?? 0) && Number.isFinite(varMedian)) {
       median = varMedian;
+      medianSource = 'variant_any';
+      medianSample = varN;
     } else if (Number.isFinite(modN) && modN >= (minSample ?? 0) && Number.isFinite(modMedian)) {
       median = modMedian;
+      medianSource = 'model_any';
+      medianSample = modN;
     } else {
       median = liveMedian;
+      medianSource = 'live';
+      medianSample = toNumber(row.n);
     }
 
     if (!Number.isFinite(total) || !Number.isFinite(median) || median <= 0) continue;
@@ -375,7 +424,7 @@ export function buildDealsFromRows(rows, limit, arg3) {
     if (!current || savingsPercent > current.savingsPercent || (savingsPercent === current.savingsPercent && total < current.total)) {
       grouped.set(modelKey, {
         row, total, price, shipping, median, savingsAmount, savingsPercent,
-        bandUsed, bandSample
+        bandUsed, bandSample, medianSource, medianSample
       });
     }
   }
@@ -392,8 +441,9 @@ export function buildDealsFromRows(rows, limit, arg3) {
     })
     .slice(0, limit);
 
-  return ranked.map(({ row, total, price, shipping, median, savingsAmount, savingsPercent, bandUsed, bandSample }) => {
+  return ranked.map(({ row, total, price, shipping, median, savingsAmount, savingsPercent, bandUsed, bandSample, medianSource, medianSample }) => {
     const label = formatModelLabel(row.model_key, row.brand, row.title);
+    const variantKey = typeof row.variant_key === 'string' ? row.variant_key : '';
     const sanitized = sanitizeModelKey(row.model_key, { storedBrand: row.brand });
     const { query: canonicalQuery, queryVariants: canonicalVariants = {}, rawLabel: rawWithAccessories, cleanLabel: cleanWithoutAccessories } = sanitized;
 
@@ -432,6 +482,7 @@ export function buildDealsFromRows(rows, limit, arg3) {
     const currency = row.currency || 'USD';
     const statsSource = row.stats_source || null;
 
+    const resolvedCondition = bandUsed || (row.cond_band || null);
     const stats = {
       p10: centsToNumber(row.p10_cents),
       p50: median,
@@ -439,7 +490,10 @@ export function buildDealsFromRows(rows, limit, arg3) {
       n: toNumber(row.n),
       dispersionRatio: toNumber(row.dispersion_ratio),
       source: statsSource,
-      usedBand: bandUsed,                 // NEW: band used for median, e.g., 'USED', 'NEW', ...
+      usedBand: resolvedCondition,
+      conditionBand: resolvedCondition,
+      variantKey: variantKey || null,
+      medianSource,
     };
     const statsMeta = {
       source: statsSource,
@@ -451,6 +505,10 @@ export function buildDealsFromRows(rows, limit, arg3) {
         ? toNumber(row.aggregated_n ?? row.n)
         : toNumber(row.live_n ?? row.n),
       bandSampleSize: bandSample,         // NEW: n used for the banded p50
+      medianSource,
+      conditionBand: resolvedCondition,
+      variantKey: variantKey || null,
+      medianSampleSize: Number.isFinite(medianSample) ? medianSample : null,
     };
     if (statsSource === 'live' && lookbackHours != null) statsMeta.lookbackHours = lookbackHours;
 
@@ -465,18 +523,36 @@ export function buildDealsFromRows(rows, limit, arg3) {
       image: row.image_url,
       observedAt: row.observed_at || null,
       condition: row.condition || null,
+      conditionBand: resolvedCondition,
       retailer: 'eBay',
       specs: { headType: row.head_type || null, dexterity: row.dexterity || null, length: toNumber(row.length_in) },
       brand: row.brand || null,
     };
 
     const grade = gradeDeal({
-      total,
-      p10: stats.p10,
-      p50: stats.p50,
-      p90: stats.p90,
-      dispersionRatio: stats.dispersionRatio
+      savingsPct: Number.isFinite(savingsPercent) ? savingsPercent : null,
     });
+
+    const conditionBand = resolvedCondition;
+    const sampleLabel = Number.isFinite(medianSample) && medianSample > 0 ? ` (n=${medianSample})` : '';
+    let gradeReason = null;
+    switch (medianSource) {
+      case 'variant_band':
+        gradeReason = `variant ${conditionBand || 'ANY'} median${sampleLabel}`;
+        break;
+      case 'model_band':
+        gradeReason = `model ${conditionBand || 'ANY'} median${sampleLabel}`;
+        break;
+      case 'variant_any':
+        gradeReason = `fallback: variant p50${sampleLabel}`;
+        break;
+      case 'model_any':
+        gradeReason = `fallback: model p50${sampleLabel}`;
+        break;
+      default:
+        gradeReason = `fallback: live p50${sampleLabel}`;
+        break;
+    }
 
     return {
       modelKey: row.model_key,
@@ -489,6 +565,14 @@ export function buildDealsFromRows(rows, limit, arg3) {
       stats,
       statsMeta,
       totalListings: toNumber(row.listing_count),
+      brand: row.brand || null,
+      model: row.model_key || null,
+      conditionBand,
+      variantKey: variantKey || null,
+      dealGrade: typeof grade.letter === 'string' ? grade.letter : null,
+      gradeReason,
+      savingsPct: Number.isFinite(savingsPercent) ? savingsPercent : null,
+      medianPrice: Number.isFinite(median) ? median : null,
       grade: {
         letter: typeof grade.letter === 'string' ? grade.letter : null,
         label: typeof grade.label === 'string' ? grade.label : null,
@@ -565,6 +649,8 @@ export default async function handler(req, res) {
     const verify = String(req.query.verify || '') === '1';
     const modelParam = (req.query.model || '').trim();
     const modelKey = modelParam ? normalizeModelKey(modelParam) : null;
+    const debugAccessories = String(req.query.debugAccessories || '') === '1';
+    const accessoryDebug = [];
 
     const startTime = Date.now();
     const fast = String(req.query.fast || '') === '1';
@@ -576,7 +662,7 @@ export default async function handler(req, res) {
     const minSavingsPct = toNumber(req.query.minSavingsPct);
 
     // Serve cached payload first (enabled by default)
-    const useCache = String(req.query.cache || '1') === '1';
+    const useCache = String(req.query.cache || '1') === '1' && !debugAccessories;
     if (useCache && !modelKey && !verify) {
       try {
         const [cached] = await sql/* sql */`
@@ -597,6 +683,8 @@ export default async function handler(req, res) {
       minSample:     Number.isFinite(minSample) ? minSample : 6,
       maxDispersion: Number.isFinite(maxDispersion) ? maxDispersion : 5,
       minSavingsPct: Number.isFinite(minSavingsPct) ? minSavingsPct : 0.20,
+      captureAccessoryDrops: debugAccessories,
+      debugAccessoryList: accessoryDebug,
     };
 
     // Try strict-ish first
@@ -611,6 +699,7 @@ export default async function handler(req, res) {
       for (const bump of FALLBACK_TRIES) {
         if (Date.now() - startTime > TIME_BUDGET_MS) break;
         const mergedFilters = {
+          ...usedFilters,
           freshnessHours: bump.freshnessHours ?? usedFilters.freshnessHours,
           minSample: bump.minSample ?? usedFilters.minSample,
           maxDispersion: bump.maxDispersion ?? usedFilters.maxDispersion,
@@ -672,7 +761,7 @@ export default async function handler(req, res) {
   }
 
   // --- RESPONSE ---------------------------------------------------
-  return res.status(200).json({
+  const payload = {
     ok: true,
     generatedAt: new Date().toISOString(),
     deals,
@@ -690,7 +779,15 @@ export default async function handler(req, res) {
       verified: !!verified,
       fallbackUsed: !!fallbackUsed,
     },
-  });
+  };
+
+  if (debugAccessories) {
+    payload.meta.debug = {
+      accessoryDrops: accessoryDebug,
+    };
+  }
+
+  return res.status(200).json(payload);
 } catch (err) {
   console.error(err);
   return res


### PR DESCRIPTION
## Summary
- tighten accessory filtering and add debugging hooks for `/api/top-deals`
- return condition-aware deal grade metadata including savings percentage and variant info
- align grading thresholds with new scale and update unit tests

## Testing
- `node --test pages/api/top-deals.test.js` *(fails: requires database module in test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68e592594dd08325a93a4f5a4932faec