### PR TITLE
Add rarity-aware price aggregation and refresh top deals endpoint

### DIFF
--- a/lib/deal-label.js
+++ b/lib/deal-label.js
@@ -1,6 +1,6 @@
-import { PUTTER_CATALOG } from './data/putterCatalog';
-import { normalizeModelKey } from './normalize';
-import { sanitizeModelKey } from './sanitizeModelKey';
+import { PUTTER_CATALOG } from './data/putterCatalog.js';
+import { normalizeModelKey } from './normalize.js';
+import { sanitizeModelKey } from './sanitizeModelKey.js';
 
 const CATALOG_LOOKUP = (() => {
   const map = new Map();

--- a/pages/api/admin/aggregate.js
+++ b/pages/api/admin/aggregate.js
@@ -5,6 +5,9 @@ import { getSql } from '../../../lib/db.js';
 import { normalizeModelKey } from '../../../lib/normalize.js';
 
 const WINDOWS = [60, 90, 180];
+const ANY_VARIANT_KEY = '__ANY__';
+const ANY_CONDITION_BAND = 'ANY';
+const ANY_RARITY_TIER = 'ANY';
 
 async function columnExists(sql, table, column) {
   const rows = await sql`
@@ -56,6 +59,8 @@ export default async function handler(req, res) {
     const hasBandCol = await columnExists(sql, 'listing_snapshots', 'condition_band');
     const hasCondText = await columnExists(sql, 'listing_snapshots', 'condition');
     const hasCondId = await columnExists(sql, 'listing_snapshots', 'condition_id');
+    const hasCategory = await columnExists(sql, 'listing_snapshots', 'category');
+    const hasRarity = await columnExists(sql, 'listing_snapshots', 'rarity_tier');
 
     // Prefer stored condition_band; else derive from text; else derive from id; else default USED
     let bandExpr = `"condition_band"`;
@@ -83,95 +88,108 @@ export default async function handler(req, res) {
       }
     }
 
+    const categoryExpr = hasCategory
+      ? `COALESCE(NULLIF(category, ''), 'putter')`
+      : `'putter'`;
+    const rarityExpr = hasRarity
+      ? `COALESCE(NULLIF(rarity_tier, ''), 'retail')`
+      : `'retail'`;
+
+    const aggHasCategory = await columnExists(sql, 'aggregated_stats_variant', 'category');
+    if (!aggHasCategory) {
+      await sql`ALTER TABLE aggregated_stats_variant ADD COLUMN IF NOT EXISTS category text NOT NULL DEFAULT 'putter'`;
+    }
+    const aggHasRarity = await columnExists(sql, 'aggregated_stats_variant', 'rarity_tier');
+    if (!aggHasRarity) {
+      await sql`ALTER TABLE aggregated_stats_variant ADD COLUMN IF NOT EXISTS rarity_tier text NOT NULL DEFAULT 'retail'`;
+    }
+
+    await sql`ALTER TABLE aggregated_stats_variant ALTER COLUMN category DROP DEFAULT`;
+    await sql`ALTER TABLE aggregated_stats_variant ALTER COLUMN rarity_tier DROP DEFAULT`;
+    await sql`ALTER TABLE aggregated_stats_variant DROP CONSTRAINT IF EXISTS aggregated_stats_variant_pkey`;
+    await sql`ALTER TABLE aggregated_stats_variant ADD CONSTRAINT aggregated_stats_variant_pkey PRIMARY KEY (model, variant_key, category, rarity_tier, condition_band, window_days)`;
+
     const results = [];
 
     for (const wd of WINDOWS) {
-      let updatedAny = 0;
-      let updatedBandsParent = 0;
-      let updatedBandsVariants = 0;
-
-      // ---------- ANY: parent + variants
-      const anyRows = await sql`
+      const rows = await sql`
         WITH data AS (
           SELECT
             LOWER(model) AS model,
             COALESCE(variant_key, '') AS variant_key,
-            ${sql.unsafe(centsExpr)} AS cents
-          FROM listing_snapshots
-          WHERE ${sql.unsafe(`"${timeCol}"`)} >= NOW() - ${wd} * INTERVAL '1 day'
-          ${onlyKey ? sql`AND model = ${onlyKey}` : sql``}
-        ),
-        agg AS (
-          SELECT
-            model,
-            variant_key,
-            COUNT(*)::int AS n,
-            (percentile_cont(0.1) WITHIN GROUP (ORDER BY cents))::numeric AS p10d,
-            (percentile_cont(0.5) WITHIN GROUP (ORDER BY cents))::numeric AS p50d,
-            (percentile_cont(0.9) WITHIN GROUP (ORDER BY cents))::numeric AS p90d
-          FROM data
-          GROUP BY 1, 2
-        )
-        INSERT INTO aggregated_stats_variant
-          (model, variant_key, condition_band, window_days,
-           n, p10_cents, p50_cents, p90_cents, dispersion_ratio, updated_at)
-        SELECT
-          model,
-          variant_key,
-          'ANY',
-          ${wd},
-          n,
-          ROUND(p10d)::int,
-          ROUND(p50d)::int,
-          ROUND(p90d)::int,
-          CASE WHEN ROUND(p10d)::int > 0
-               THEN (ROUND(p90d)::int - ROUND(p10d)::int)::numeric / ROUND(p10d)::int
-               ELSE NULL
-          END,
-          NOW()
-        FROM agg
-        ON CONFLICT (model, variant_key, condition_band, window_days)
-        DO UPDATE SET
-          n = EXCLUDED.n,
-          p10_cents = EXCLUDED.p10_cents,
-          p50_cents = EXCLUDED.p50_cents,
-          p90_cents = EXCLUDED.p90_cents,
-          dispersion_ratio = EXCLUDED.dispersion_ratio,
-          updated_at = EXCLUDED.updated_at
-        RETURNING model, variant_key
-      `;
-      updatedAny += anyRows.length;
-
-      // ---------- Bands: parent + variants
-      const bandRows = await sql`
-        WITH data AS (
-          SELECT
-            LOWER(model) AS model,
-            COALESCE(variant_key, '') AS variant_key,
+            ${sql.unsafe(categoryExpr)} AS category,
+            ${sql.unsafe(rarityExpr)} AS rarity_tier,
             ${sql.unsafe(bandExpr)} AS condition_band,
             ${sql.unsafe(centsExpr)} AS cents
           FROM listing_snapshots
           WHERE ${sql.unsafe(`"${timeCol}"`)} >= NOW() - ${wd} * INTERVAL '1 day'
-          ${onlyKey ? sql`AND model = ${onlyKey}` : sql``}
+            AND ${sql.unsafe(centsExpr)} IS NOT NULL
+            ${onlyKey ? sql`AND model = ${onlyKey}` : sql``}
         ),
-        agg AS (
+        granular AS (
           SELECT
             model,
             variant_key,
+            category,
+            rarity_tier,
             condition_band,
             COUNT(*)::int AS n,
             (percentile_cont(0.1) WITHIN GROUP (ORDER BY cents))::numeric AS p10d,
             (percentile_cont(0.5) WITHIN GROUP (ORDER BY cents))::numeric AS p50d,
             (percentile_cont(0.9) WITHIN GROUP (ORDER BY cents))::numeric AS p90d
           FROM data
-          GROUP BY 1, 2, 3
+          GROUP BY 1, 2, 3, 4, 5
+        ),
+        model_variant AS (
+          SELECT
+            model,
+            ${ANY_VARIANT_KEY}::text AS variant_key,
+            category,
+            rarity_tier,
+            condition_band,
+            COUNT(*)::int AS n,
+            (percentile_cont(0.1) WITHIN GROUP (ORDER BY cents))::numeric AS p10d,
+            (percentile_cont(0.5) WITHIN GROUP (ORDER BY cents))::numeric AS p50d,
+            (percentile_cont(0.9) WITHIN GROUP (ORDER BY cents))::numeric AS p90d
+          FROM data
+          GROUP BY 1, 3, 4, 5
+        ),
+        model_condition AS (
+          SELECT
+            model,
+            ${ANY_VARIANT_KEY}::text AS variant_key,
+            category,
+            rarity_tier,
+            ${ANY_CONDITION_BAND}::text AS condition_band,
+            COUNT(*)::int AS n,
+            (percentile_cont(0.1) WITHIN GROUP (ORDER BY cents))::numeric AS p10d,
+            (percentile_cont(0.5) WITHIN GROUP (ORDER BY cents))::numeric AS p50d,
+            (percentile_cont(0.9) WITHIN GROUP (ORDER BY cents))::numeric AS p90d
+          FROM data
+          GROUP BY 1, 3, 4
+        ),
+        model_any AS (
+          SELECT
+            model,
+            ${ANY_VARIANT_KEY}::text AS variant_key,
+            category,
+            ${ANY_RARITY_TIER}::text AS rarity_tier,
+            ${ANY_CONDITION_BAND}::text AS condition_band,
+            COUNT(*)::int AS n,
+            (percentile_cont(0.1) WITHIN GROUP (ORDER BY cents))::numeric AS p10d,
+            (percentile_cont(0.5) WITHIN GROUP (ORDER BY cents))::numeric AS p50d,
+            (percentile_cont(0.9) WITHIN GROUP (ORDER BY cents))::numeric AS p90d
+          FROM data
+          GROUP BY 1, 3
         )
         INSERT INTO aggregated_stats_variant
-          (model, variant_key, condition_band, window_days,
+          (model, variant_key, category, rarity_tier, condition_band, window_days,
            n, p10_cents, p50_cents, p90_cents, dispersion_ratio, updated_at)
         SELECT
           model,
           variant_key,
+          category,
+          rarity_tier,
           condition_band,
           ${wd},
           n,
@@ -179,12 +197,66 @@ export default async function handler(req, res) {
           ROUND(p50d)::int,
           ROUND(p90d)::int,
           CASE WHEN ROUND(p10d)::int > 0
-               THEN (ROUND(p90d)::int - ROUND(p10d)::int)::numeric / ROUND(p10d)::int
+               THEN ROUND(p90d)::numeric / NULLIF(ROUND(p10d)::numeric, 0)
                ELSE NULL
           END,
           NOW()
-        FROM agg
-        ON CONFLICT (model, variant_key, condition_band, window_days)
+        FROM granular
+        UNION ALL
+        SELECT
+          model,
+          variant_key,
+          category,
+          rarity_tier,
+          condition_band,
+          ${wd},
+          n,
+          ROUND(p10d)::int,
+          ROUND(p50d)::int,
+          ROUND(p90d)::int,
+          CASE WHEN ROUND(p10d)::int > 0
+               THEN ROUND(p90d)::numeric / NULLIF(ROUND(p10d)::numeric, 0)
+               ELSE NULL
+          END,
+          NOW()
+        FROM model_variant
+        UNION ALL
+        SELECT
+          model,
+          variant_key,
+          category,
+          rarity_tier,
+          condition_band,
+          ${wd},
+          n,
+          ROUND(p10d)::int,
+          ROUND(p50d)::int,
+          ROUND(p90d)::int,
+          CASE WHEN ROUND(p10d)::int > 0
+               THEN ROUND(p90d)::numeric / NULLIF(ROUND(p10d)::numeric, 0)
+               ELSE NULL
+          END,
+          NOW()
+        FROM model_condition
+        UNION ALL
+        SELECT
+          model,
+          variant_key,
+          category,
+          rarity_tier,
+          condition_band,
+          ${wd},
+          n,
+          ROUND(p10d)::int,
+          ROUND(p50d)::int,
+          ROUND(p90d)::int,
+          CASE WHEN ROUND(p10d)::int > 0
+               THEN ROUND(p90d)::numeric / NULLIF(ROUND(p10d)::numeric, 0)
+               ELSE NULL
+          END,
+          NOW()
+        FROM model_any
+        ON CONFLICT (model, variant_key, category, rarity_tier, condition_band, window_days)
         DO UPDATE SET
           n = EXCLUDED.n,
           p10_cents = EXCLUDED.p10_cents,
@@ -192,19 +264,30 @@ export default async function handler(req, res) {
           p90_cents = EXCLUDED.p90_cents,
           dispersion_ratio = EXCLUDED.dispersion_ratio,
           updated_at = EXCLUDED.updated_at
-        RETURNING model, variant_key
+        RETURNING model, variant_key, category, rarity_tier, condition_band
       `;
 
-      for (const r of bandRows) {
-        if (r.variant_key) updatedBandsVariants++;
-        else updatedBandsParent++;
-      }
+      const counts = rows.reduce(
+        (acc, row) => {
+          if (row.variant_key === ANY_VARIANT_KEY) {
+            if (row.condition_band === ANY_CONDITION_BAND && row.rarity_tier === ANY_RARITY_TIER) {
+              acc.updatedModelAny += 1;
+            } else if (row.condition_band === ANY_CONDITION_BAND) {
+              acc.updatedModelCondition += 1;
+            } else {
+              acc.updatedModelVariant += 1;
+            }
+          } else {
+            acc.updatedGranular += 1;
+          }
+          return acc;
+        },
+        { updatedGranular: 0, updatedModelVariant: 0, updatedModelCondition: 0, updatedModelAny: 0 }
+      );
 
       results.push({
         windowDays: wd,
-        updatedAny,
-        updatedBands: updatedBandsParent,
-        updatedVariants: updatedBandsVariants,
+        ...counts,
       });
     }
 

--- a/pages/api/top-deals.js
+++ b/pages/api/top-deals.js
@@ -2,11 +2,8 @@
 export const runtime = 'nodejs';
 
 import { getSql } from '../../lib/db';
-import { getEbayToken } from '../../lib/ebayAuth';
-import { sanitizeModelKey, stripAccessoryTokens } from '../../lib/sanitizeModelKey';
 import { decorateEbayUrl } from '../../lib/affiliate';
 import { gradeDeal } from '../../lib/deal-grade';
-import { composeDealLabel, formatModelLabel } from '../../lib/deal-label';
 import { normalizeModelKey } from '../../lib/normalize';
 import { evaluateAccessoryGuard } from '../../lib/text-filters';
 import {
@@ -15,751 +12,503 @@ import {
   isCollectorModeEnabled,
 } from '../../lib/config/collectorFlags';
 
-// ---------- Hobby-friendly performance knobs ----------
-const TIME_BUDGET_MS = 7500;                  // well under Hobby cap (~10s)
-const FAST_WINDOWS = [72, 168, 336, 720];               // fewer windows for ?fast=1
+const AVAILABLE_WINDOWS = [60, 90, 180];
+const DEFAULT_LIMIT = 12;
+const DEFAULT_LOOKBACK_HOURS = 168; // 7 days
+const DEFAULT_FRESHNESS_HOURS = 48;
+const DEFAULT_MIN_SAMPLE = 6;
+const DEFAULT_MIN_SAVINGS = 0.2;
+const DEFAULT_MAX_DISPERSION = 5;
+const DEFAULT_CATEGORIES = ['putter', 'headcover'];
 
-// Default windows (strict → broader)
-const DEFAULT_LOOKBACK_WINDOWS_HOURS = [24, 72, 168, 336, 720];
+const ANY_VARIANT_KEY = '__ANY__';
+const ANY_CONDITION_BAND = 'ANY';
+const ANY_RARITY_TIER = 'ANY';
+const DEFAULT_RARITY = 'retail';
+const DEFAULT_CATEGORY = 'putter';
 
-// Auto-relax ladder so the endpoint rarely returns empty
-const FALLBACK_TRIES = [
-  { freshnessHours: 48,  minSample: 8, minSavingsPct: 0.20, maxDispersion: 5 },
-  { freshnessHours: 48,  minSample: 6, minSavingsPct: 0.20, maxDispersion: 5 },
-  { freshnessHours: 48,  minSample: 5, minSavingsPct: 0.15, maxDispersion: 5 },
-  { lookbackWindowHours: 168, freshnessHours: 72, minSample: 5, minSavingsPct: 0.15, maxDispersion: 5 },
-  { lookbackWindowHours: 336, freshnessHours: 72, minSample: 4, minSavingsPct: 0.12, maxDispersion: 5.5 },
-  { lookbackWindowHours: 720, freshnessHours: 72, minSample: 3, minSavingsPct: 0.10, maxDispersion: 6 },
-  { lookbackWindowHours: 720, freshnessHours: 96, minSample: 0,  minSavingsPct: 0.00, maxDispersion: 8 } // last resort so cache isn't empty
-];
-
-// ---------- small utils ----------
-function toNumber(v) { const n = Number(v); return Number.isFinite(n) ? n : null; }
-function centsToNumber(v) { const n = toNumber(v); return n == null ? null : n / 100; }
-function ensurePutterQuery(text = '') {
-  let s = String(text || '').trim();
-  if (!s) return 'golf putter';
-  s = s.replace(/\bputters\b/gi, 'putter');
-  if (!/\bputter\b/i.test(s)) s = `${s} putter`;
-  return s.replace(/\s+/g, ' ').trim();
+function toFiniteNumber(value) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
 }
 
-// ---------- fast=1 helper: if aggregates exist, ignore live_* fields afterwards ----------
-function fastRows(rows) {
-  return rows.map(r =>
-    r.stats_source === 'aggregated'
-      ? { ...r, live_n: null, live_p10_cents: null, live_p50_cents: null, live_p90_cents: null, live_dispersion_ratio: null }
-      : r
-  );
+function centsToDollars(value) {
+  const num = toFiniteNumber(value);
+  return num == null ? null : num / 100;
 }
 
-// ---------- Main SQL ----------
-async function queryTopDeals(sql, since, modelKey = null) {
+function parseCategoryList(param) {
+  if (!param) return [...DEFAULT_CATEGORIES];
+  const parts = String(param)
+    .split(',')
+    .map(v => v.trim().toLowerCase())
+    .filter(Boolean)
+    .filter(v => v !== 'accessory');
+  const unique = Array.from(new Set(parts));
+  return unique.length ? unique : [...DEFAULT_CATEGORIES];
+}
+
+function normalizeCategory(value) {
+  const v = (value || '').toLowerCase();
+  return v || DEFAULT_CATEGORY;
+}
+
+function normalizeRarity(value) {
+  if (!value) return DEFAULT_RARITY;
+  if (value === ANY_RARITY_TIER) return ANY_RARITY_TIER;
+  const v = String(value).toLowerCase();
+  if (v === 'any') return ANY_RARITY_TIER;
+  return v || DEFAULT_RARITY;
+}
+
+function normalizeCondition(value) {
+  const v = (value || '').toUpperCase();
+  return v || ANY_CONDITION_BAND;
+}
+
+function normalizeVariant(value) {
+  return typeof value === 'string' ? value : '';
+}
+
+function normalizeModel(value) {
+  return (value || '').toLowerCase();
+}
+
+function pickWindowDays(hours) {
+  const targetHours = toFiniteNumber(hours);
+  const targetDays = Number.isFinite(targetHours)
+    ? Math.max(1, targetHours / 24)
+    : DEFAULT_LOOKBACK_HOURS / 24;
+  let best = AVAILABLE_WINDOWS[0];
+  let bestDiff = Math.abs(best - targetDays);
+  for (let i = 1; i < AVAILABLE_WINDOWS.length; i += 1) {
+    const w = AVAILABLE_WINDOWS[i];
+    const diff = Math.abs(w - targetDays);
+    if (diff < bestDiff) {
+      best = w;
+      bestDiff = diff;
+    }
+  }
+  return best;
+}
+
+function aggregateKey(model, variantKey, category, rarityTier, conditionBand) {
+  return [model, variantKey, category, rarityTier, conditionBand].join('||');
+}
+
+async function fetchLiveItems(sql, { freshnessHours, categories, modelKey }) {
+  const hours = Math.max(1, Math.floor(freshnessHours || DEFAULT_FRESHNESS_HOURS));
+  const categoryList = categories.length ? categories : [...DEFAULT_CATEGORIES];
   const rows = await sql/* sql */`
     WITH latest_prices AS (
-      SELECT DISTINCT ON (p.item_id)
-        p.item_id, p.observed_at, p.price, p.shipping,
-        COALESCE(p.total, p.price + COALESCE(p.shipping, 0)) AS total,
-        p.condition
-      FROM item_prices p
-      WHERE p.observed_at >= ${since}
-      ORDER BY p.item_id, p.observed_at DESC
+      SELECT DISTINCT ON (ip.item_id)
+        ip.item_id,
+        ip.price,
+        ip.shipping,
+        COALESCE(ip.total, ip.price + COALESCE(ip.shipping, 0)) AS total,
+        ip.observed_at
+      FROM item_prices ip
+      WHERE ip.observed_at >= NOW() - ${hours} * INTERVAL '1 hour'
+      ORDER BY ip.item_id, ip.observed_at DESC
     ),
-    base_stats AS (
-      SELECT DISTINCT ON (model)
-        model, window_days, n, p10_cents, p50_cents, p90_cents,
-        dispersion_ratio, updated_at
-      FROM aggregated_stats_variant
-      WHERE variant_key = '' AND condition_band = 'ANY' AND n >= 1
-      ORDER BY model, window_days DESC, updated_at DESC
-    ),
-    model_counts AS (
-      SELECT i.model_key, COUNT(*) AS listing_count
-      FROM latest_prices lp
-      JOIN items i ON i.item_id = lp.item_id
-      WHERE i.model_key IS NOT NULL AND i.model_key <> ''
-      GROUP BY i.model_key
+    latest_snapshot AS (
+      SELECT DISTINCT ON (ls.item_id)
+        ls.item_id,
+        COALESCE(NULLIF(ls.variant_key, ''), '') AS variant_key,
+        COALESCE(NULLIF(ls.category, ''), NULL) AS category,
+        COALESCE(NULLIF(ls.rarity_tier, ''), NULL) AS rarity_tier,
+        COALESCE(NULLIF(ls.condition_band, ''), NULL) AS condition_band
+      FROM listing_snapshots ls
+      ORDER BY ls.item_id, ls.snapshot_ts DESC NULLS LAST
     )
     SELECT
-      i.model_key, i.brand, i.title, i.image_url, i.url,
-      i.currency, i.head_type, i.dexterity, i.length_in,
-      lp.item_id, lp.price, lp.shipping, lp.total, lp.observed_at, lp.condition,
-      COALESCE(stats.n, live.live_n) AS n,
-      stats.window_days,
-      COALESCE(stats.p10_cents, live.live_p10_cents) AS p10_cents,
-      COALESCE(stats.p50_cents, live.live_p50_cents) AS p50_cents,
-      COALESCE(stats.p90_cents, live.live_p90_cents) AS p90_cents,
-      COALESCE(stats.dispersion_ratio, live.live_dispersion_ratio) AS dispersion_ratio,
-      COALESCE(stats.updated_at, live.latest_observed_at) AS updated_at,
-      mc.listing_count,
-      CASE WHEN stats.p50_cents IS NOT NULL THEN 'aggregated'
-           WHEN live.live_p50_cents IS NOT NULL THEN 'live'
-           ELSE NULL END AS stats_source,
-      stats.n AS aggregated_n,
-      stats.updated_at AS aggregated_updated_at,
-      live.live_n,
-      live.latest_observed_at AS live_updated_at,
-
-      -- ANY medians (variant/model)
-      av.var_n, av.var_p50_cents, av.var_window,
-      am.mod_n, am.mod_p50_cents, am.mod_window,
-
-      -- BAND medians (variant/model)
-      avb.var_band_n, avb.var_band_p50_cents, avb.var_band_window,
-      amb.mod_band_n, amb.mod_band_p50_cents, amb.mod_band_window,
-
-      -- Which band this listing is in
-      c.cond_band,
-
-      COALESCE(v.variant_key, '') AS variant_key
-
+      i.item_id,
+      i.title,
+      i.url,
+      i.brand,
+      i.model_key,
+      COALESCE(NULLIF(ls.category, ''), i.category) AS category,
+      COALESCE(NULLIF(ls.rarity_tier, ''), i.rarity_tier) AS rarity_tier,
+      COALESCE(NULLIF(ls.condition_band, ''), i.condition_band) AS condition_band,
+      COALESCE(ls.variant_key, '') AS variant_key,
+      i.currency,
+      lp.price,
+      lp.shipping,
+      lp.total,
+      lp.observed_at
     FROM latest_prices lp
     JOIN items i ON i.item_id = lp.item_id
-    LEFT JOIN base_stats stats ON stats.model = i.model_key
-
-    -- latest variant_key for this item
-    LEFT JOIN LATERAL (
-      SELECT ls.variant_key
-      FROM listing_snapshots ls
-      WHERE ls.item_id = lp.item_id
-        AND ls.variant_key IS NOT NULL
-        AND ls.variant_key <> ''
-      ORDER BY ls.snapshot_ts DESC
-      LIMIT 1
-    ) v ON TRUE
-
-    -- Map eBay conditionId -> band for this row
-   -- Map eBay conditionId → condition_band (robust for text/int)
-LEFT JOIN LATERAL (
-  SELECT CASE
-    WHEN lp.condition::text IN ('1000') THEN 'NEW'
-    WHEN lp.condition::text IN ('1500','2000','2500','2750') THEN 'MINT'
-    WHEN lp.condition::text IN ('3000') THEN 'USED'
-    WHEN lp.condition::text IN ('4000') THEN 'VERY_GOOD'
-    WHEN lp.condition::text IN ('5000') THEN 'GOOD'
-    WHEN lp.condition::text IN ('6000') THEN 'ACCEPTABLE'
-    ELSE 'ANY'
-  END AS cond_band
-) c ON TRUE
-
-
-    -- Variant + ANY
-    LEFT JOIN LATERAL (
-      SELECT n AS var_n, p50_cents AS var_p50_cents, window_days AS var_window
-      FROM aggregated_stats_variant a
-      WHERE a.model = i.model_key
-        AND a.variant_key = COALESCE(v.variant_key, '')
-        AND a.condition_band = 'ANY'
-      ORDER BY a.window_days DESC
-      LIMIT 1
-    ) av ON TRUE
-
-    -- Variant + BAND (preferred)
-    LEFT JOIN LATERAL (
-      SELECT n AS var_band_n, p50_cents AS var_band_p50_cents, window_days AS var_band_window
-      FROM aggregated_stats_variant a
-      WHERE a.model = i.model_key
-        AND a.variant_key = COALESCE(v.variant_key, '')
-        AND a.condition_band = c.cond_band
-      ORDER BY a.window_days DESC
-      LIMIT 1
-    ) avb ON TRUE
-
-    -- Model + ANY
-    LEFT JOIN LATERAL (
-      SELECT n AS mod_n, p50_cents AS mod_p50_cents, window_days AS mod_window
-      FROM aggregated_stats_variant a2
-      WHERE a2.model = i.model_key
-        AND a2.variant_key = ''
-        AND a2.condition_band = 'ANY'
-      ORDER BY a2.window_days DESC
-      LIMIT 1
-    ) am ON TRUE
-
-    -- Model + BAND
-    LEFT JOIN LATERAL (
-      SELECT n AS mod_band_n, p50_cents AS mod_band_p50_cents, window_days AS mod_band_window
-      FROM aggregated_stats_variant a2
-      WHERE a2.model = i.model_key
-        AND a2.variant_key = ''
-        AND a2.condition_band = c.cond_band
-      ORDER BY a2.window_days DESC
-      LIMIT 1
-    ) amb ON TRUE
-
-    -- Live percentiles ONLY when aggregates missing (cheap gate)
-    LEFT JOIN LATERAL (
-      SELECT
-        COUNT(*) AS live_n,
-        percentile_cont(0.1) WITHIN GROUP (ORDER BY lp2.total) * 100 AS live_p10_cents,
-        percentile_cont(0.5) WITHIN GROUP (ORDER BY lp2.total) * 100 AS live_p50_cents,
-        percentile_cont(0.9) WITHIN GROUP (ORDER BY lp2.total) * 100 AS live_p90_cents,
-        MAX(lp2.observed_at) AS latest_observed_at,
-        CASE
-          WHEN percentile_cont(0.1) WITHIN GROUP (ORDER BY lp2.total) IS NOT NULL
-            AND percentile_cont(0.1) WITHIN GROUP (ORDER BY lp2.total) <> 0
-          THEN (percentile_cont(0.9) WITHIN GROUP (ORDER BY lp2.total) /
-               NULLIF(percentile_cont(0.1) WITHIN GROUP (ORDER BY lp2.total), 0))
-          ELSE NULL
-        END AS live_dispersion_ratio
-      FROM latest_prices lp2
-      JOIN items i2 ON i2.item_id = lp2.item_id
-      WHERE i2.model_key = i.model_key
-        AND lp2.total IS NOT NULL AND lp2.total > 0
-        AND (stats.p50_cents IS NULL) -- do not compute live if aggregated exists
-    ) AS live ON TRUE
-
-    LEFT JOIN model_counts mc ON mc.model_key = i.model_key
+    LEFT JOIN latest_snapshot ls ON ls.item_id = lp.item_id
     WHERE i.model_key IS NOT NULL AND i.model_key <> ''
       AND lp.total IS NOT NULL AND lp.total > 0
       ${modelKey ? sql`AND i.model_key = ${modelKey}` : sql``}
-      AND (stats.p50_cents IS NOT NULL OR live.live_p50_cents IS NOT NULL)
+      AND COALESCE(NULLIF(ls.category, ''), i.category, ${DEFAULT_CATEGORY}) = ANY(${sql.array(categoryList, 'text')})
+      AND COALESCE(NULLIF(ls.category, ''), i.category, ${DEFAULT_CATEGORY}) <> 'accessory'
   `;
-  return rows;
-}
 
-// ---------- Deal computation ----------
-export function buildDealsFromRows(rows, limit, arg3) {
-  const opts = (typeof arg3 === 'number' || arg3 == null)
-    ? { lookbackHours: (typeof arg3 === 'number' ? arg3 : null) }
-    : (arg3 || {});
-
-  const {
-    now = new Date(),
-    freshnessHours = null,
-    minSample = null,
-    maxDispersion = null,
-    minSavingsPct = 0,
-    lookbackHours = null,
-    debugAccessoryList = null,
-    captureAccessoryDrops = false,
-  } = opts;
-
-  const grouped = new Map();
-
-  const debugSink = Array.isArray(debugAccessoryList) ? debugAccessoryList : null;
-
+  const items = [];
   for (const row of rows) {
-    const title = row?.title || '';
-    const modelKey = row.model_key || '';
+    const guard = evaluateAccessoryGuard(row?.title || '');
+    if (guard.isAccessory) continue;
 
-    const recordDrop = (reason, extra = {}) => {
-      if (!captureAccessoryDrops || !debugSink) return;
-      const payload = {
-        title,
-        reason,
-        ...(extra && typeof extra === 'object' ? extra : {}),
-      };
-      if (row?.item_id) payload.itemId = row.item_id;
-      if (row?.model_key) payload.modelKey = row.model_key;
-      debugSink.push(payload);
-    };
+    const modelKeyNorm = normalizeModel(row.model_key);
+    const category = normalizeCategory(row.category);
+    const rarityTier = normalizeRarity(row.rarity_tier);
+    const conditionBand = normalizeCondition(row.condition_band);
+    const variantKey = normalizeVariant(row.variant_key);
+    const price = toFiniteNumber(row.price);
+    const shipping = toFiniteNumber(row.shipping);
+    const total = toFiniteNumber(row.total);
+    if (!Number.isFinite(total) || total <= 0) continue;
 
-    const guard = evaluateAccessoryGuard(title);
-
-    if (guard.isAccessory) {
-      recordDrop(guard.reason || 'accessory_filtered', {
-        dropTokens: guard.dropTokens,
-        hasCoreToken: guard.hasCoreToken,
-      });
-      continue;
-    }
-
-    if (!modelKey) {
-      recordDrop('missing_model_key', {
-        hasCoreToken: guard.hasCoreToken,
-      });
-      continue;
-    }
-
-    const total = toNumber(row.total);
-    const price = toNumber(row.price);
-    const shipping = toNumber(row.shipping);
-    const variantKey = typeof row.variant_key === 'string' ? row.variant_key : '';
-
-    // ANY-band medians
-    const varMedian = centsToNumber(row.var_p50_cents);
-    const varN = toNumber(row.var_n);
-    const modMedian = centsToNumber(row.mod_p50_cents);
-    const modN = toNumber(row.mod_n);
-
-    // BAND-specific medians
-    const varBandMedian = centsToNumber(row.var_band_p50_cents);
-    const varBandN = toNumber(row.var_band_n);
-    const modBandMedian = centsToNumber(row.mod_band_p50_cents);
-    const modBandN = toNumber(row.mod_band_n);
-    const usedBand = row.cond_band || null;
-
-    const liveMedian = centsToNumber(row.p50_cents);
-
-    // Choose median by fallback: variant+band → model+band → variant+ANY → model+ANY → live
-    let median = null;
-    let bandSample = null;
-    let bandUsed = null;
-    let medianSource = null;
-    let medianSample = null;
-
-
-    if (Number.isFinite(varBandN) && varBandN >= (minSample ?? 0) && Number.isFinite(varBandMedian)) {
-      median = varBandMedian;
-      bandSample = varBandN;
-      bandUsed = usedBand;
-      medianSource = 'variant_band';
-      medianSample = varBandN;
-    } else if (Number.isFinite(modBandN) && modBandN >= (minSample ?? 0) && Number.isFinite(modBandMedian)) {
-      median = modBandMedian;
-      bandSample = modBandN;
-      bandUsed = usedBand;
-      medianSource = 'model_band';
-      medianSample = modBandN;
-    } else if (Number.isFinite(varN) && varN >= (minSample ?? 0) && Number.isFinite(varMedian)) {
-      median = varMedian;
-      medianSource = 'variant_any';
-      medianSample = varN;
-    } else if (Number.isFinite(modN) && modN >= (minSample ?? 0) && Number.isFinite(modMedian)) {
-      median = modMedian;
-      medianSource = 'model_any';
-      medianSample = modN;
-    } else {
-      median = liveMedian;
-      medianSource = 'live';
-      medianSample = toNumber(row.n);
-    }
-
-    if (!Number.isFinite(total) || !Number.isFinite(median) || median <= 0) continue;
-
-    // Global sample/dispersion gates (from aggregate/live row)
-    const sampleSize = toNumber(row.n);
-    const dispersion = toNumber(row.dispersion_ratio);
-    if (minSample != null && sampleSize != null && sampleSize < minSample) continue;
-    if (maxDispersion != null && dispersion != null && dispersion > maxDispersion) continue;
-
-    // Freshness gate on THIS listing
-    if (freshnessHours != null && row.observed_at) {
-      const obs = new Date(row.observed_at);
-      if (now - obs > freshnessHours * 3600 * 1000) continue;
-    }
-
-    const savingsAmount = median - total;
-    const savingsPercent = median > 0 ? savingsAmount / median : null;
-    if (!Number.isFinite(savingsPercent) || savingsPercent <= (minSavingsPct ?? 0)) continue;
-
-    const current = grouped.get(modelKey);
-    if (!current || savingsPercent > current.savingsPercent || (savingsPercent === current.savingsPercent && total < current.total)) {
-      grouped.set(modelKey, {
-        row, total, price, shipping, median, savingsAmount, savingsPercent,
-        bandUsed, bandSample, medianSource, medianSample
-      });
-    }
-  }
-
-  const ranked = Array.from(grouped.values())
-    .sort((a, b) => {
-      if (Number.isFinite(b.savingsPercent) && Number.isFinite(a.savingsPercent) && b.savingsPercent !== a.savingsPercent) {
-        return b.savingsPercent - a.savingsPercent;
-      }
-      if (Number.isFinite(a.total) && Number.isFinite(b.total) && a.total !== b.total) {
-        return a.total - b.total;
-      }
-      return 0;
-    })
-    .slice(0, limit);
-
-  return ranked.map(({ row, total, price, shipping, median, savingsAmount, savingsPercent, bandUsed, bandSample, medianSource, medianSample }) => {
-    const sanitized = sanitizeModelKey(row.model_key, { storedBrand: row.brand });
-    const { label, brand: displayBrand } = composeDealLabel(row, sanitized);
-    const variantKey = typeof row.variant_key === 'string' ? row.variant_key : '';
-    const { query: canonicalQuery, queryVariants: canonicalVariants = {}, rawLabel: rawWithAccessories, cleanLabel: cleanWithoutAccessories } = sanitized;
-
-    let cleanQuery = canonicalQuery || null;
-    let accessoryQuery = canonicalVariants.accessory || null;
-    let query = cleanQuery;
-
-    const fallbackCandidates = [
-      label,
-      formatModelLabel(row.model_key, row.brand, row.title),
-      [row.brand, row.title].filter(Boolean).join(' ').trim(),
-    ].filter(Boolean);
-
-    if (!query && row.brand) {
-      const brandBacked = sanitizeModelKey(`${row.brand} ${row.model_key}`, { storedBrand: row.brand });
-      if (brandBacked?.query) { query = brandBacked.query; cleanQuery = cleanQuery || brandBacked.query; }
-      if (!accessoryQuery && brandBacked?.queryVariants?.accessory) accessoryQuery = brandBacked.queryVariants.accessory;
-    }
-    if (!query) {
-      for (const candidate of fallbackCandidates) {
-        const s = sanitizeModelKey(candidate, { storedBrand: row.brand });
-        if (s?.query) { query = s.query; cleanQuery = cleanQuery || s.query; if (!accessoryQuery && s?.queryVariants?.accessory) accessoryQuery = s.queryVariants.accessory; break; }
-      }
-    }
-    if (!query) {
-      const base = stripAccessoryTokens(`${row.brand || ''} ${label}`.trim());
-      query = ensurePutterQuery(base || label || row.brand || '');
-      if (!cleanQuery) cleanQuery = query;
-      const accessoryBase = `${row.brand || ''} ${label}`.trim();
-      if (!accessoryQuery && accessoryBase) accessoryQuery = ensurePutterQuery(accessoryBase);
-    }
-
-    const labelWasAccessoryOnly = Boolean(rawWithAccessories) && !cleanWithoutAccessories;
-    const shouldPromoteAccessoryQuery = Boolean(accessoryQuery) && labelWasAccessoryOnly && !cleanQuery;
-    if (shouldPromoteAccessoryQuery) query = accessoryQuery; else if (cleanQuery) query = cleanQuery;
-
-    const currency = row.currency || 'USD';
-    const statsSource = row.stats_source || null;
-
-    const resolvedCondition = bandUsed || (row.cond_band || null);
-    const stats = {
-      p10: centsToNumber(row.p10_cents),
-      p50: median,
-      p90: centsToNumber(row.p90_cents),
-      n: toNumber(row.n),
-      dispersionRatio: toNumber(row.dispersion_ratio),
-      source: statsSource,
-      usedBand: resolvedCondition,
-      conditionBand: resolvedCondition,
-      variantKey: variantKey || null,
-      medianSource,
-    };
-    const statsMeta = {
-      source: statsSource,
-      windowDays: statsSource === 'aggregated' ? toNumber(row.window_days) : null,
-      updatedAt: statsSource === 'aggregated'
-        ? (row.aggregated_updated_at || row.updated_at || null)
-        : (row.live_updated_at || row.updated_at || null),
-      sampleSize: statsSource === 'aggregated'
-        ? toNumber(row.aggregated_n ?? row.n)
-        : toNumber(row.live_n ?? row.n),
-      bandSampleSize: bandSample,         // NEW: n used for the banded p50
-      medianSource,
-      conditionBand: resolvedCondition,
-      variantKey: variantKey || null,
-      medianSampleSize: Number.isFinite(medianSample) ? medianSample : null,
-    };
-    if (statsSource === 'live' && lookbackHours != null) statsMeta.lookbackHours = lookbackHours;
-
-    const bestOffer = {
+    items.push({
       itemId: row.item_id,
-      title: row.title,
-      url: decorateEbayUrl(row.url),
-      price,
-      total,
-      shipping,
-      currency,
-      image: row.image_url,
-      observedAt: row.observed_at || null,
-      condition: row.condition || null,
-      conditionBand: resolvedCondition,
-      retailer: 'eBay',
-      specs: { headType: row.head_type || null, dexterity: row.dexterity || null, length: toNumber(row.length_in) },
-      brand: displayBrand || row.brand || null,
-    };
-
-    const grade = gradeDeal({
-      savingsPct: Number.isFinite(savingsPercent) ? savingsPercent : null,
-    });
-
-    const conditionBand = resolvedCondition;
-    const sampleLabel = Number.isFinite(medianSample) && medianSample > 0 ? ` (n=${medianSample})` : '';
-    let gradeReason = null;
-    switch (medianSource) {
-      case 'variant_band':
-        gradeReason = `variant ${conditionBand || 'ANY'} median${sampleLabel}`;
-        break;
-      case 'model_band':
-        gradeReason = `model ${conditionBand || 'ANY'} median${sampleLabel}`;
-        break;
-      case 'variant_any':
-        gradeReason = `fallback: variant p50${sampleLabel}`;
-        break;
-      case 'model_any':
-        gradeReason = `fallback: model p50${sampleLabel}`;
-        break;
-      default:
-        gradeReason = `fallback: live p50${sampleLabel}`;
-        break;
-    }
-
-    return {
-      modelKey: row.model_key,
-      label,
-      query,
-      image: row.image_url || null,
-      currency,
-      bestPrice: total,
-      bestOffer,
-      stats,
-      statsMeta,
-      totalListings: toNumber(row.listing_count),
+      title: row.title || '',
+      url: row.url || '',
       brand: row.brand || null,
-      model: row.model_key || null,
+      modelKey: modelKeyNorm,
+      originalModelKey: row.model_key || null,
+      category,
+      rarityTier,
       conditionBand,
-      variantKey: variantKey || null,
-      dealGrade: typeof grade.letter === 'string' ? grade.letter : null,
-      gradeReason,
-      savingsPct: Number.isFinite(savingsPercent) ? savingsPercent : null,
-      medianPrice: Number.isFinite(median) ? median : null,
-      grade: {
-        letter: typeof grade.letter === 'string' ? grade.letter : null,
-        label: typeof grade.label === 'string' ? grade.label : null,
-        color: typeof grade.color === 'string' ? grade.color : null,
-        deltaPct: Number.isFinite(grade.deltaPct) ? grade.deltaPct : null,
-      },
-      savings: {
-        amount: Number.isFinite(savingsAmount) ? savingsAmount : null,
-        percent: Number.isFinite(savingsPercent) ? savingsPercent : null,
-      },
-      queryVariants: { clean: cleanQuery || null, accessory: accessoryQuery || null },
+      variantKey,
+      currency: row.currency || 'USD',
+      price,
+      shipping,
+      total,
+      observedAt: row.observed_at || null,
+    });
+  }
+  return items;
+}
+
+async function fetchAggregates(sql, models, categories, windowDays) {
+  if (!models.size) return new Map();
+  const modelList = Array.from(models);
+  const categoryList = categories.length ? categories : [...DEFAULT_CATEGORIES];
+  const rows = await sql/* sql */`
+    SELECT
+      model,
+      COALESCE(variant_key, '') AS variant_key,
+      category,
+      rarity_tier,
+      condition_band,
+      window_days,
+      n,
+      p10_cents,
+      p50_cents,
+      p90_cents,
+      dispersion_ratio,
+      updated_at
+    FROM aggregated_stats_variant
+    WHERE model = ANY(${sql.array(modelList, 'text')})
+      AND window_days = ${windowDays}
+      AND category = ANY(${sql.array(categoryList, 'text')})
+  `;
+
+  const map = new Map();
+  for (const row of rows) {
+    const model = normalizeModel(row.model);
+    const variantKey = normalizeVariant(row.variant_key);
+    const category = normalizeCategory(row.category);
+    const rarityRaw = row.rarity_tier || DEFAULT_RARITY;
+    const rarityTier = rarityRaw === ANY_RARITY_TIER ? ANY_RARITY_TIER : normalizeRarity(rarityRaw);
+    const conditionBand = row.condition_band === ANY_CONDITION_BAND
+      ? ANY_CONDITION_BAND
+      : normalizeCondition(row.condition_band);
+
+    const key = aggregateKey(model, variantKey, category, rarityTier, conditionBand);
+    const current = map.get(key);
+    const next = {
+      model,
+      variant_key: variantKey,
+      category,
+      rarity_tier: rarityTier,
+      condition_band: conditionBand,
+      window_days: Number(row.window_days),
+      n: row.n == null ? null : Number(row.n),
+      p10_cents: row.p10_cents == null ? null : Number(row.p10_cents),
+      p50_cents: row.p50_cents == null ? null : Number(row.p50_cents),
+      p90_cents: row.p90_cents == null ? null : Number(row.p90_cents),
+      dispersion_ratio: row.dispersion_ratio == null ? null : Number(row.dispersion_ratio),
+      updated_at: row.updated_at,
     };
-  });
-}
-
-// ---------- Optional 404 verification against eBay (fail-open) ----------
-async function verifyDealsActive(deals = []) {
-  try {
-    const token = await getEbayToken();
-    const out = [];
-    for (const d of deals) {
-      try {
-        const id = d?.bestOffer?.itemId || d?.itemId || d?.id;
-        if (!id) { out.push(d); continue; }
-        const r = await fetch(`https://api.ebay.com/buy/browse/v1/item/${id}`, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            'Content-Type': 'application/json',
-            'X-EBAY-C-MARKETPLACE-ID': 'EBAY_US',
-          },
-        });
-        if (r.status === 404) continue;
-        if (!r.ok) continue;
-        out.push(d);
-      } catch {
-        out.push(d);
-      }
+    if (!current) {
+      map.set(key, next);
+      continue;
     }
-    return out;
-  } catch {
-    return deals;
+    const currentTs = current.updated_at ? new Date(current.updated_at).getTime() : 0;
+    const nextTs = next.updated_at ? new Date(next.updated_at).getTime() : 0;
+    if (nextTs >= currentTs) {
+      map.set(key, next);
+    }
   }
+  return map;
 }
 
-// ---------- Loader that tries windows with time budget ----------
-async function loadRankedDeals(sql, limit, windows, filters, modelKey = null, fast = false, startTime = Date.now()) {
-  const windowsToTry = Array.isArray(windows) && windows.length ? windows : DEFAULT_LOOKBACK_WINDOWS_HOURS;
-  let deals = [];
-  let usedWindow = windowsToTry[windowsToTry.length - 1] ?? null;
+function chooseAggregate(map, { modelKey, variantKey, category, rarityTier, conditionBand, minSample }) {
+  const fallbackPaths = [
+    { variant: variantKey, condition: conditionBand, rarity: rarityTier },
+    { variant: ANY_VARIANT_KEY, condition: conditionBand, rarity: rarityTier },
+    { variant: ANY_VARIANT_KEY, condition: ANY_CONDITION_BAND, rarity: rarityTier },
+    { variant: ANY_VARIANT_KEY, condition: ANY_CONDITION_BAND, rarity: DEFAULT_RARITY },
+    { variant: ANY_VARIANT_KEY, condition: ANY_CONDITION_BAND, rarity: ANY_RARITY_TIER },
+  ];
 
-  for (const hours of windowsToTry) {
-    const since = new Date(Date.now() - hours * 3600 * 1000);
-    if (Date.now() - startTime > TIME_BUDGET_MS) break;
-    const rows = await queryTopDeals(sql, since, modelKey);
-    const usedRows = fast ? fastRows(rows) : rows;
-    const computed = buildDealsFromRows(usedRows, limit, { ...filters, lookbackHours: hours });
-    deals = computed;
-    usedWindow = hours;
-    if (computed.length > 0) break;
+  for (let idx = 0; idx < fallbackPaths.length; idx += 1) {
+    const path = fallbackPaths[idx];
+    const key = aggregateKey(modelKey, path.variant, category, path.rarity, path.condition);
+    const row = map.get(key);
+    if (!row) continue;
+    if (Number.isFinite(minSample) && minSample > 0) {
+      const n = toFiniteNumber(row.n);
+      if (!Number.isFinite(n) || n < minSample) continue;
+    }
+    return { aggregate: row, fallbackLevel: idx };
+  }
+  return null;
+}
+
+function buildDeal(item, aggregate, fallbackLevel, { minSavingsPct, maxDispersion }) {
+  const p50 = centsToDollars(aggregate.p50_cents);
+  if (!Number.isFinite(p50) || p50 <= 0) return null;
+  const total = toFiniteNumber(item.total);
+  if (!Number.isFinite(total) || total <= 0) return null;
+
+  const savingsPct = 1 - total / p50;
+  if (Number.isFinite(minSavingsPct) && savingsPct < minSavingsPct) return null;
+
+  const dispersion = toFiniteNumber(aggregate.dispersion_ratio);
+  if (Number.isFinite(maxDispersion) && Number.isFinite(dispersion) && dispersion > maxDispersion) {
+    return null;
   }
 
-  return { deals, windowHours: usedWindow };
-}
-export { loadRankedDeals };
+  const p10 = centsToDollars(aggregate.p10_cents);
+  const p90 = centsToDollars(aggregate.p90_cents);
+  const savingsAmount = Number.isFinite(p50) && Number.isFinite(total) ? p50 - total : null;
 
-// ---------- API handler ----------
+  const grade = gradeDeal({ savingsPct });
+
+  const bestOffer = {
+    price: item.price,
+    total,
+    shipping: item.shipping,
+    currency: item.currency,
+    url: decorateEbayUrl(item.url),
+    title: item.title,
+  };
+
+  return {
+    brand: item.brand,
+    model: item.originalModelKey,
+    modelKey: item.modelKey,
+    variantKey: item.variantKey || null,
+    category: item.category,
+    rarityTier: item.rarityTier,
+    conditionBand: item.conditionBand,
+    bestOffer,
+    savingsPct,
+    savings: {
+      amount: savingsAmount,
+      percent: savingsPct,
+    },
+    grade: grade.letter,
+    gradeMeta: grade,
+    fallbackLevel,
+    usedFallback: fallbackLevel > 0,
+    stats: {
+      p10,
+      p50,
+      p90,
+      n: aggregate.n,
+    },
+    statsMeta: {
+      windowDays: aggregate.window_days,
+      bandSampleSize: aggregate.n,
+      dispersionRatio: dispersion,
+      updatedAt: aggregate.updated_at || null,
+      fallbackLevel,
+      sourceVariant: aggregate.variant_key,
+    },
+  };
+}
+
+async function loadDeals(sql, {
+  limit,
+  freshnessHours,
+  categories,
+  modelKey,
+  windowDays,
+  minSample,
+  minSavingsPct,
+  maxDispersion,
+}) {
+  const items = await fetchLiveItems(sql, { freshnessHours, categories, modelKey });
+  if (!items.length) {
+    return { deals: [], fallbackUsed: false };
+  }
+
+  const models = new Set(items.map(item => item.modelKey).filter(Boolean));
+  const aggregateMap = await fetchAggregates(sql, models, categories, windowDays);
+
+  const deals = [];
+  let fallbackUsed = false;
+
+  for (const item of items) {
+    const choice = chooseAggregate(aggregateMap, {
+      modelKey: item.modelKey,
+      variantKey: item.variantKey,
+      category: item.category,
+      rarityTier: item.rarityTier,
+      conditionBand: item.conditionBand,
+      minSample,
+    });
+    if (!choice) continue;
+
+    const deal = buildDeal(item, choice.aggregate, choice.fallbackLevel, {
+      minSavingsPct,
+      maxDispersion,
+    });
+    if (!deal) continue;
+
+    fallbackUsed = fallbackUsed || choice.fallbackLevel > 0;
+    deals.push(deal);
+  }
+
+  deals.sort((a, b) => (b.savingsPct ?? 0) - (a.savingsPct ?? 0));
+  const limited = deals.slice(0, limit);
+  return { deals: limited, fallbackUsed };
+}
+
 export default async function handler(req, res) {
   try {
     const sql = getSql();
 
-    // Parse query
-    const limit = Math.min(12, Math.max(3, toNumber(req.query.limit) ?? 12));
-    const lookback = toNumber(req.query.lookbackWindowHours) || null;
-    const verifyMode = String(req.query.verify || '') === '1';
-    const modelParam = (req.query.model || '').trim();
-    const modelKey = modelParam ? normalizeModelKey(modelParam) : null;
-    const debugAccessories = String(req.query.debugAccessories || '') === '1';
-    const accessoryDebug = [];
+    const limitParam = toFiniteNumber(req.query.limit);
+    const limit = Number.isFinite(limitParam)
+      ? Math.max(1, Math.min(24, Math.floor(limitParam)))
+      : DEFAULT_LIMIT;
 
-    const startTime = Date.now();
-    const fast = String(req.query.fast || '') === '1';
-    const windows = lookback ? [lookback] : (fast ? FAST_WINDOWS : DEFAULT_LOOKBACK_WINDOWS_HOURS);
+    const lookbackParam = toFiniteNumber(req.query.lookbackWindowHours);
+    const windowDays = pickWindowDays(lookbackParam ?? DEFAULT_LOOKBACK_HOURS);
+    const lookbackWindowHours = windowDays * 24;
 
-    const freshnessHours = toNumber(req.query.freshnessHours);
-    const minSample = toNumber(req.query.minSample);
-    const maxDispersion = toNumber(req.query.maxDispersion);
-    const minSavingsPct = toNumber(req.query.minSavingsPct);
+    const freshnessParam = toFiniteNumber(req.query.freshnessHours);
+    const freshnessHours = Number.isFinite(freshnessParam)
+      ? Math.max(1, freshnessParam)
+      : DEFAULT_FRESHNESS_HOURS;
+
+    const minSampleParam = toFiniteNumber(req.query.minSample);
+    const minSample = Number.isFinite(minSampleParam)
+      ? Math.max(0, Math.floor(minSampleParam))
+      : DEFAULT_MIN_SAMPLE;
+
+    const minSavingsParam = toFiniteNumber(req.query.minSavingsPct);
+    const minSavingsPct = Number.isFinite(minSavingsParam)
+      ? minSavingsParam
+      : DEFAULT_MIN_SAVINGS;
+
+    const maxDispersionParam = toFiniteNumber(req.query.maxDispersion);
+    const maxDispersion = Number.isFinite(maxDispersionParam)
+      ? maxDispersionParam
+      : DEFAULT_MAX_DISPERSION;
+
+    const categories = parseCategoryList(req.query.categoryIn);
+
+    const rawModel = String(req.query.model || '').trim();
+    const normalizedModelKey = rawModel ? normalizeModelKey(rawModel) : null;
+    const modelKey = normalizedModelKey ? normalizeModel(normalizedModelKey) : null;
+
+    const cacheWrite = String(req.query.cacheWrite || '') === '1';
+    const useCache = String(req.query.cache || '1') === '1';
 
     const collectorMode = isCollectorModeEnabled();
     const cacheKey = collectorMode ? getTopDealsCacheKey() : 'default';
-    const fallbackCacheKey = 'default';
-    const cacheSecrets = getAllowedCacheSecrets();
 
-    // Serve cached payload first (enabled by default)
-    const useCache = String(req.query.cache || '1') === '1' && !debugAccessories;
-    if (useCache && !modelKey && !verifyMode) {
+    if (useCache && !modelKey) {
       try {
-        const [primary] = await sql/* sql */`
-          SELECT cache_key, payload, generated_at FROM top_deals_cache WHERE cache_key = ${cacheKey}
+        const [cached] = await sql/* sql */`
+          SELECT cache_key, payload, generated_at
+          FROM top_deals_cache
+          WHERE cache_key = ${cacheKey}
         `;
-
-        let cached = primary;
-
-        if (!cached?.payload && collectorMode && cacheKey !== fallbackCacheKey) {
-          const [fallback] = await sql/* sql */`
-            SELECT cache_key, payload, generated_at FROM top_deals_cache WHERE cache_key = ${fallbackCacheKey}
-          `;
-          if (fallback?.payload) {
-            cached = fallback;
-          }
-        }
-
         if (cached?.payload) {
           const payload = { ...cached.payload };
-          const baseMeta =
-            payload.meta && typeof payload.meta === 'object'
-              ? { ...payload.meta }
-              : {};
-          const meta = {
-            ...baseMeta,
-            cache: {
-              key: cached.cache_key || cacheKey,
-              generatedAt: cached.generated_at,
-            },
-            ...(collectorMode ? { collectorMode: true } : {}),
+          const meta = payload.meta && typeof payload.meta === 'object'
+            ? { ...payload.meta }
+            : {};
+          meta.cache = {
+            key: cached.cache_key || cacheKey,
+            generatedAt: cached.generated_at,
           };
-
-          if (collectorMode && (cached.cache_key || cacheKey) !== cacheKey) {
-            meta.cache.requestedKey = cacheKey;
-          }
-
-          return res.status(200).json({
-            ...payload,
-            meta,
-          });
+          payload.meta = meta;
+          return res.status(200).json(payload);
         }
-      } catch { /* fall through */ }
-    }
-
-    // Friendlier defaults while aggregates deepen (keeps homepage populated)
-    const filters = {
-      freshnessHours: Number.isFinite(freshnessHours) ? freshnessHours : 48,
-      minSample:     Number.isFinite(minSample) ? minSample : 6,
-      maxDispersion: Number.isFinite(maxDispersion) ? maxDispersion : 5,
-      minSavingsPct: Number.isFinite(minSavingsPct) ? minSavingsPct : 0.20,
-      captureAccessoryDrops: debugAccessories,
-      debugAccessoryList: accessoryDebug,
-    };
-
-    // Try strict-ish first
-    let { deals: baseDeals, windowHours } = await loadRankedDeals(sql, limit, windows, filters, modelKey, fast, startTime);
-    let deals = verifyMode ? await verifyDealsActive(baseDeals) : baseDeals;
-
-    // Auto-relax progressively if empty
-    let usedFilters = { ...filters };
-    let fallbackUsed = false;
-
-    if (deals.length === 0) {
-      for (const bump of FALLBACK_TRIES) {
-        if (Date.now() - startTime > TIME_BUDGET_MS) break;
-        const mergedFilters = {
-          ...usedFilters,
-          freshnessHours: bump.freshnessHours ?? usedFilters.freshnessHours,
-          minSample: bump.minSample ?? usedFilters.minSample,
-          maxDispersion: bump.maxDispersion ?? usedFilters.maxDispersion,
-          minSavingsPct: bump.minSavingsPct ?? usedFilters.minSavingsPct,
-        };
-        const windows2 = bump.lookbackWindowHours ? [bump.lookbackWindowHours] : windows;
-        const res2 = await loadRankedDeals(sql, limit, windows2, mergedFilters, modelKey, fast, startTime);
-        const d2 = verifyMode ? await verifyDealsActive(res2.deals) : res2.deals;
-        if (d2.length > 0) {
-          deals = d2;
-          windowHours = res2.windowHours;
-          usedFilters = mergedFilters;
-          fallbackUsed = true;
-          break;
-        }
+      } catch (err) {
+        console.error('top-deals cache read failed', err);
       }
     }
 
-    // Optional: write computed payload into cache (for nightly cron)
-    const cacheWrite = String(req.query.cacheWrite || '') === '1';
-
-    const incomingSecret = String(req.headers['x-cron-secret'] || '');
-    const okAuth = incomingSecret && cacheSecrets.includes(incomingSecret);
-
-    const modelCount = Array.isArray(deals) ? deals.length : 0;
-    const lookbackWindowHours = windowHours ?? null;
-
-    const baseMeta = {
+    const { deals, fallbackUsed } = await loadDeals(sql, {
       limit,
-      modelCount,
-      lookbackWindowHours,
-      modelKey: modelKey || null,
-      filters: {
-        freshnessHours,
-        minSample,
-        maxDispersion,
-        minSavingsPct,
-      },
-      verified: !!verifyMode,
-      fallbackUsed: !!fallbackUsed,
-    };
+      freshnessHours,
+      categories,
+      modelKey,
+      windowDays,
+      minSample,
+      minSavingsPct,
+      maxDispersion,
+    });
 
     const generatedAt = new Date().toISOString();
-    const baseCacheMeta = {
-      key: cacheKey,
-      generatedAt,
-    };
-    const baseCollectorMeta = collectorMode ? { collectorMode: true } : {};
-
-    const meta = {
-      ...baseMeta,
-      cache: baseCacheMeta,
-      ...baseCollectorMeta,
-    };
+    const verified = false;
 
     const payload = {
       ok: true,
       generatedAt,
       deals,
-      meta: { ...meta },
+      meta: {
+        limit,
+        modelCount: deals.length,
+        lookbackWindowHours,
+        modelKey: normalizedModelKey || null,
+        filters: {
+          freshnessHours,
+          minSample,
+          maxDispersion,
+          minSavingsPct,
+        },
+        verified,
+        fallbackUsed,
+        cache: cacheWrite ? { key: cacheKey, generatedAt } : null,
+      },
     };
 
-    const shouldWrite =
-      cacheWrite &&
-      okAuth &&
-      Array.isArray(deals) &&
-      deals.length > 0;
-
-    if (shouldWrite) {
-      const cachePayload = {
-        ...payload,
-        meta: { ...payload.meta },
-      };
-
-      await sql/* sql */`
-        INSERT INTO top_deals_cache (cache_key, payload)
-        VALUES (${cacheKey}, ${JSON.stringify(cachePayload)}::jsonb)
-        ON CONFLICT (cache_key) DO UPDATE
-        SET payload = EXCLUDED.payload,
-            generated_at = now()
-      `;
+    if (collectorMode) {
+      payload.meta.collectorMode = true;
     }
 
-    if (debugAccessories) {
-      payload.filteredOut = accessoryDebug;
-      payload.meta = {
-        ...payload.meta,
-        debug: {
-          accessoryDrops: accessoryDebug,
-        },
-      };
+    const cacheSecrets = getAllowedCacheSecrets();
+    const incomingSecret = String(req.headers['x-cron-secret'] || '');
+    const canWriteCache = cacheWrite && cacheSecrets.includes(incomingSecret) && deals.length > 0;
+
+    if (canWriteCache) {
+      try {
+        await sql/* sql */`
+          INSERT INTO top_deals_cache (cache_key, payload)
+          VALUES (${cacheKey}, ${JSON.stringify(payload)}::jsonb)
+          ON CONFLICT (cache_key) DO UPDATE
+          SET payload = EXCLUDED.payload,
+              generated_at = NOW()
+        `;
+      } catch (err) {
+        console.error('top-deals cache write failed', err);
+      }
     }
 
     return res.status(200).json(payload);
-  } catch (err) {
-    console.error(err);
-    return res
-      .status(500)
-    .json({ ok: false, error: err?.message || String(err) });
- }
-
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
 }
-


### PR DESCRIPTION
## Summary
- extend the admin aggregate task to capture category and rarity tiers, update the rollup schema, and publish variant/model fallback rows for each window
- rebuild the top-deals API around condition/rarity-aware aggregates with the required fallback ladder, filters, and response metadata while keeping cache support

## Testing
- not run (database-backed API endpoints)


------
https://chatgpt.com/codex/tasks/task_e_68e6a93b024c8325bc1538fd6aaafff5