### PR TITLE
Refine collector homepage and putter filters

### DIFF
--- a/components/RarityBadge.jsx
+++ b/components/RarityBadge.jsx
@@ -1,0 +1,53 @@
+import clsx from "clsx";
+
+const RARITY_CONFIG = {
+  tour: {
+    emoji: "🟣",
+    label: "Tour",
+    className: "bg-purple-100 text-purple-800 ring-purple-200",
+  },
+  limited: {
+    emoji: "🟡",
+    label: "Limited",
+    className: "bg-amber-100 text-amber-800 ring-amber-200",
+  },
+  retail: {
+    emoji: "🔵",
+    label: "Retail",
+    className: "bg-blue-100 text-blue-800 ring-blue-200",
+  },
+};
+
+function normalizeTier(value) {
+  if (!value) return null;
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === "tour-only" || normalized === "touronly") return "tour";
+  if (normalized === "limited-run" || normalized === "limitedrun") return "limited";
+  if (normalized === "retail-line" || normalized === "retailline") return "retail";
+  if (normalized in RARITY_CONFIG) return normalized;
+  if (normalized.includes("tour")) return "tour";
+  if (normalized.includes("limit")) return "limited";
+  if (normalized.includes("retail")) return "retail";
+  return null;
+}
+
+export default function RarityBadge({ tier, className }) {
+  const normalized = normalizeTier(tier);
+  if (!normalized) return null;
+  const cfg = RARITY_CONFIG[normalized];
+  if (!cfg) return null;
+
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ring-1 ring-inset",
+        cfg.className,
+        className
+      )}
+    >
+      <span aria-hidden="true">{cfg.emoji}</span>
+      <span>{cfg.label}</span>
+    </span>
+  );
+}

--- a/lib/search-normalize.ts
+++ b/lib/search-normalize.ts
@@ -218,7 +218,7 @@ export function buildCanonicalQuery(details: BuildCanonicalQueryDetails = {}): s
     base = formatFullModelName(details);
   }
 
-  const variantHint = humanizeVariantKey(details.variantKey);
+  const variantHint = humanizeVariantKey(details.variantKey ?? undefined);
   if (variantHint) {
     const lowerBase = base.toLowerCase();
     if (!lowerBase.includes(variantHint.toLowerCase())) {

--- a/lib/search-normalize.ts
+++ b/lib/search-normalize.ts
@@ -3,30 +3,54 @@ import { normalizeModelKey as normalizeCatalogKey } from "./normalize";
 import { sanitizeModelKey, stripAccessoryTokens } from "./sanitizeModelKey";
 import { formatFullModelName, humanizeVariantKey } from "./format-model";
 
-function canonicalKey(value = "") {
-  const normalized = normalizeCatalogKey(String(value || "").replace(/[|]/g, " "));
+interface CatalogEntry {
+  brand: string;
+  model: string;
+  normalizedKey: string;
+  canonicalName: string;
+}
+
+interface ResolvedModel extends CatalogEntry {
+  aliasQueries: string[];
+}
+
+interface BuildCanonicalQueryDetails {
+  brand?: string | null;
+  model?: string | null;
+  modelKey?: string | null;
+  label?: string | null;
+  rawLabel?: string | null;
+  query?: string | null;
+  bestOfferTitle?: string | null;
+  bestOffer?: { title?: string | null; brand?: string | null } | null;
+  variantKey?: string | null;
+  rarityTier?: string | null;
+}
+
+function canonicalKey(value: string | null | undefined): string {
+  const normalized = normalizeCatalogKey(String(value ?? "").replace(/[|]/g, " "));
   return normalized.replace(/\s+/g, " ").trim();
 }
 
-function synonymKey(value = "") {
-  return String(value || "")
+function synonymKey(value: string | null | undefined): string {
+  return String(value ?? "")
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "");
 }
 
-function splitTokens(value = "") {
-  return String(value || "")
+function splitTokens(value: string | null | undefined): string[] {
+  return String(value ?? "")
     .toLowerCase()
     .split(/[^a-z0-9]+/)
     .map((part) => part.trim())
     .filter(Boolean);
 }
 
-const MODEL_LOOKUP = new Map();
-const SYNONYM_LOOKUP = new Map();
-const ALIAS_QUERIES = new Map();
+const MODEL_LOOKUP = new Map<string, CatalogEntry>();
+const SYNONYM_LOOKUP = new Map<string, string>();
+const ALIAS_QUERIES = new Map<string, Set<string>>();
 
-function registerModel(brand, model) {
+function registerModel(brand: string, model: string) {
   const canonical = canonicalKey(`${brand} ${model}`);
   if (!canonical) return;
   if (!MODEL_LOOKUP.has(canonical)) {
@@ -39,7 +63,7 @@ function registerModel(brand, model) {
   }
 }
 
-function registerAlias(canonicalName, alias) {
+function registerAlias(canonicalName: string, alias: string) {
   const canonical = canonicalKey(canonicalName);
   if (!canonical) return;
   const aliasKey = synonymKey(alias);
@@ -48,7 +72,7 @@ function registerAlias(canonicalName, alias) {
   if (!ALIAS_QUERIES.has(canonical)) {
     ALIAS_QUERIES.set(canonical, new Set());
   }
-  ALIAS_QUERIES.get(canonical).add(alias.trim());
+  ALIAS_QUERIES.get(canonical)?.add(alias.trim());
 }
 
 for (const entry of PUTTER_CATALOG) {
@@ -86,12 +110,12 @@ for (const cfg of SYNONYM_CONFIG) {
   }
 }
 
-function resolveFromTokens(tokens = []) {
+function resolveFromTokens(tokens: string[]): string | null {
   for (let i = 0; i < tokens.length; i += 1) {
     const token = tokens[i];
     const directKey = synonymKey(token);
     if (directKey && SYNONYM_LOOKUP.has(directKey)) {
-      return SYNONYM_LOOKUP.get(directKey);
+      return SYNONYM_LOOKUP.get(directKey) ?? null;
     }
   }
 
@@ -99,7 +123,7 @@ function resolveFromTokens(tokens = []) {
     const pair = `${tokens[i]}${tokens[i + 1]}`;
     const pairKey = synonymKey(pair);
     if (pairKey && SYNONYM_LOOKUP.has(pairKey)) {
-      return SYNONYM_LOOKUP.get(pairKey);
+      return SYNONYM_LOOKUP.get(pairKey) ?? null;
     }
     const spaced = canonicalKey(`${tokens[i]} ${tokens[i + 1]}`);
     if (spaced && MODEL_LOOKUP.has(spaced)) {
@@ -110,28 +134,28 @@ function resolveFromTokens(tokens = []) {
   return null;
 }
 
-export function resolveModelKeyFromQuery(rawQuery = "") {
+export function resolveModelKeyFromQuery(rawQuery: string | null | undefined): ResolvedModel | null {
   if (!rawQuery) return null;
   const baseNormalized = canonicalKey(rawQuery);
   if (baseNormalized && MODEL_LOOKUP.has(baseNormalized)) {
-    const entry = MODEL_LOOKUP.get(baseNormalized);
-    const aliases = Array.from(ALIAS_QUERIES.get(entry.normalizedKey) || []);
+    const entry = MODEL_LOOKUP.get(baseNormalized)!;
+    const aliases = Array.from(ALIAS_QUERIES.get(entry.normalizedKey) ?? []);
     return { ...entry, aliasQueries: aliases };
   }
 
   const tokens = splitTokens(rawQuery);
   const tokenCandidate = resolveFromTokens(tokens);
   if (tokenCandidate && MODEL_LOOKUP.has(tokenCandidate)) {
-    const entry = MODEL_LOOKUP.get(tokenCandidate);
-    const aliases = Array.from(ALIAS_QUERIES.get(entry.normalizedKey) || []);
+    const entry = MODEL_LOOKUP.get(tokenCandidate)!;
+    const aliases = Array.from(ALIAS_QUERIES.get(entry.normalizedKey) ?? []);
     return { ...entry, aliasQueries: aliases };
   }
 
   const stripped = stripAccessoryTokens(rawQuery);
   const strippedNormalized = canonicalKey(stripped);
   if (strippedNormalized && MODEL_LOOKUP.has(strippedNormalized)) {
-    const entry = MODEL_LOOKUP.get(strippedNormalized);
-    const aliases = Array.from(ALIAS_QUERIES.get(entry.normalizedKey) || []);
+    const entry = MODEL_LOOKUP.get(strippedNormalized)!;
+    const aliases = Array.from(ALIAS_QUERIES.get(entry.normalizedKey) ?? []);
     return { ...entry, aliasQueries: aliases };
   }
 
@@ -142,8 +166,8 @@ export function resolveModelKeyFromQuery(rawQuery = "") {
     const recombined = [sanitizedBrand, sanitizedLabel].filter(Boolean).join(" ");
     const recombinedKey = canonicalKey(recombined);
     if (recombinedKey && MODEL_LOOKUP.has(recombinedKey)) {
-      const entry = MODEL_LOOKUP.get(recombinedKey);
-      const aliases = Array.from(ALIAS_QUERIES.get(entry.normalizedKey) || []);
+      const entry = MODEL_LOOKUP.get(recombinedKey)!;
+      const aliases = Array.from(ALIAS_QUERIES.get(entry.normalizedKey) ?? []);
       return { ...entry, aliasQueries: aliases };
     }
   }
@@ -151,9 +175,18 @@ export function resolveModelKeyFromQuery(rawQuery = "") {
   return null;
 }
 
-export function buildCanonicalQuery(details = {}) {
-  const brand = details.brand || details.bestOffer?.brand || "";
-  const candidates = [
+function rarityHintFromTier(tier: string | null | undefined): string {
+  if (!tier) return "";
+  const normalized = String(tier).toLowerCase();
+  if (normalized.includes("tour")) return "tour only";
+  if (normalized.includes("limit")) return "limited";
+  if (normalized.includes("retail")) return "retail";
+  return "";
+}
+
+export function buildCanonicalQuery(details: BuildCanonicalQueryDetails = {}): string {
+  const brand = (details.brand ?? details.bestOffer?.brand ?? "").trim();
+  const candidates: Array<string | null | undefined> = [
     details.modelKey,
     details.model,
     details.label,
@@ -164,7 +197,7 @@ export function buildCanonicalQuery(details = {}) {
     [brand, details.model].filter(Boolean).join(" "),
   ];
 
-  let resolved = null;
+  let resolved: ResolvedModel | null = null;
   for (const candidate of candidates) {
     if (!candidate) continue;
     const entry = resolveModelKeyFromQuery(candidate);
@@ -193,6 +226,14 @@ export function buildCanonicalQuery(details = {}) {
     }
   }
 
+  const rarityHint = rarityHintFromTier(details.rarityTier);
+  if (rarityHint) {
+    const lowerBase = base.toLowerCase();
+    if (!lowerBase.includes(rarityHint)) {
+      base = `${base} ${rarityHint}`.trim();
+    }
+  }
+
   if (!/\bputter\b/i.test(base)) {
     base = `${base} putter`;
   }
@@ -200,4 +241,4 @@ export function buildCanonicalQuery(details = {}) {
   return base.replace(/\s+/g, " ").trim();
 }
 
-export default buildCanonicalQuery;
+export type { BuildCanonicalQueryDetails, ResolvedModel };

--- a/pages/api/putters.js
+++ b/pages/api/putters.js
@@ -12,7 +12,7 @@ import {
   stripHeadcoverSpecTokens,
 } from "../../lib/sanitizeModelKey.js";
 import { BRAND_LIMITED_TOKENS } from "../../lib/config/brandLimitedTokens.js";
-import { buildCanonicalQuery, resolveModelKeyFromQuery } from "../../lib/search-normalize.js";
+import { buildCanonicalQuery, resolveModelKeyFromQuery } from "../../lib/search-normalize";
 
 /**
  * Required ENV (Vercel + .env.local):


### PR DESCRIPTION
## Summary
- restructure the homepage collector experience with dedicated putter/headcover grids and updated deal cards
- add a reusable rarity badge and move canonical query helpers to a typed implementation for better normalization
- introduce category/rarity tabs and simplified flat cards on the /putters page with smarter filtering and pricing context

## Testing
- npm run lint *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68e6b0d88fc08325bf8a343edcb3e109