### PR TITLE
Add headcover seeds and streamline badge helpers

### DIFF
--- a/components/ConditionChip.jsx
+++ b/components/ConditionChip.jsx
@@ -1,0 +1,26 @@
+export default function ConditionChip({ band }) {
+  if (!band) return null;
+
+  const normalized = String(band || "")
+    .trim()
+    .toUpperCase();
+  if (!normalized) return null;
+
+  const labels = {
+    NEW: "New",
+    LIKE_NEW: "Like New",
+    GOOD: "Good",
+    USED: "Used",
+    FAIR: "Fair",
+    ANY: "Any Condition",
+  };
+
+  const label = labels[normalized];
+  if (!label) return null;
+
+  return (
+    <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-700">
+      {label}
+    </span>
+  );
+}

--- a/components/RarityBadge.jsx
+++ b/components/RarityBadge.jsx
@@ -1,53 +1,11 @@
-import clsx from "clsx";
-
-const RARITY_CONFIG = {
-  tour: {
-    emoji: "🟣",
-    label: "Tour",
-    className: "bg-purple-100 text-purple-800 ring-purple-200",
-  },
-  limited: {
-    emoji: "🟡",
-    label: "Limited",
-    className: "bg-amber-100 text-amber-800 ring-amber-200",
-  },
-  retail: {
-    emoji: "🔵",
-    label: "Retail",
-    className: "bg-blue-100 text-blue-800 ring-blue-200",
-  },
-};
-
-function normalizeTier(value) {
-  if (!value) return null;
-  const normalized = String(value).trim().toLowerCase();
-  if (!normalized) return null;
-  if (normalized === "tour-only" || normalized === "touronly") return "tour";
-  if (normalized === "limited-run" || normalized === "limitedrun") return "limited";
-  if (normalized === "retail-line" || normalized === "retailline") return "retail";
-  if (normalized in RARITY_CONFIG) return normalized;
-  if (normalized.includes("tour")) return "tour";
-  if (normalized.includes("limit")) return "limited";
-  if (normalized.includes("retail")) return "retail";
-  return null;
-}
-
-export default function RarityBadge({ tier, className }) {
-  const normalized = normalizeTier(tier);
-  if (!normalized) return null;
-  const cfg = RARITY_CONFIG[normalized];
-  if (!cfg) return null;
-
+export default function RarityBadge({ tier }) {
+  if (!tier) return null;
+  const map = { tour: "Tour", limited: "Limited", retail: "Retail" };
+  const label = map[(tier || "").toLowerCase()];
+  if (!label) return null;
   return (
-    <span
-      className={clsx(
-        "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ring-1 ring-inset",
-        cfg.className,
-        className
-      )}
-    >
-      <span aria-hidden="true">{cfg.emoji}</span>
-      <span>{cfg.label}</span>
+    <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-700">
+      {label}
     </span>
   );
 }

--- a/data/seed-models.txt
+++ b/data/seed-models.txt
@@ -130,3 +130,12 @@ PXG Battle Ready Closer
 # Wilson
 Wilson Staff Infinite Windy City
 Wilson Staff Model BL22
+
+# Headcovers
+Scotty Cameron headcover
+Scotty Cameron Circle T headcover
+Scotty Cameron Jet Set headcover
+Scotty Cameron Button Back headcover
+Swag Golf headcover
+Bettinardi Hive headcover
+Lamb Crafted headcover

--- a/lib/format-model.js
+++ b/lib/format-model.js
@@ -79,11 +79,11 @@ export function formatFullModelName(details = {}) {
   ];
 
   const { brand: resolvedBrand, label: resolvedLabel } = deriveSanitizedLabel({ brand, candidates });
-  let workingLabel = resolvedLabel || details.model || "";
-  let workingBrand = resolvedBrand || brand;
+  let workingLabel = (resolvedLabel || details.model || "").trim();
+  let workingBrand = (resolvedBrand || brand || "").trim();
 
   if (!workingLabel && details.model) {
-    workingLabel = details.model;
+    workingLabel = String(details.model || "").trim();
   }
 
   const variantHint = humanizeVariantKey(details.variantKey);
@@ -96,7 +96,9 @@ export function formatFullModelName(details = {}) {
 
   const combined = combineBrandAndLabel(workingBrand, workingLabel);
   if (combined) {
-    return combined;
+    const normalizedBrand = (workingBrand || "").trim();
+    const brandOnly = normalizedBrand && combined.trim().toLowerCase() === normalizedBrand.toLowerCase();
+    if (!brandOnly) return combined;
   }
 
   if (workingBrand) {


### PR DESCRIPTION
## Summary
- simplify the rarity badge and add a dedicated condition chip component for condition bands
- prevent `formatFullModelName` from returning a brand-only label by requiring a model token
- seed cron browse jobs with initial headcover models alongside putter queries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6b621d7708325abd68152babe696f